### PR TITLE
refactor: change navigation route name

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
   <application android:name="${applicationName}" android:label="wecount" android:icon="@mipmap/launcher_icon">
-    <meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyAg6X2S4WjIgl_Zkhiz5ZHYW8q-s4fzgRA"/>
+    <meta-data android:name="com.google.android.geo.API_KEY" android:value="@string/geo_api_key"/>
     <activity android:name=".MainActivity" android:exported="true" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
       <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -17,11 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>$(FLUTTER_BUILD_NAME)</string>
+		<!-- <string>$(FLUTTER_BUILD_NAME)</string> -->
+		<string>1</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleVersion</key>
-		<string>$(FLUTTER_BUILD_NUMBER)</string>
+		<!-- <string>$(FLUTTER_BUILD_NUMBER)</string> -->
+		<string>1.0</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>UILaunchStoryboardName</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -17,13 +17,11 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<!-- <string>$(FLUTTER_BUILD_NAME)</string> -->
-		<string>1</string>
+		<string>$(FLUTTER_BUILD_NAME)</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleVersion</key>
-		<!-- <string>$(FLUTTER_BUILD_NUMBER)</string> -->
-		<string>1.0</string>
+		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>UILaunchStoryboardName</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,7 @@ import './utils/localization.dart';
 
 void main() async {
   await _initFire();
-  runApp(MyApp());
+  runApp(const MyApp());
   _fcmListeners();
 }
 
@@ -55,6 +55,7 @@ void _fcmListeners() {
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
   static const supportedLocales = ['en', 'ko'];
 
   @override
@@ -69,6 +70,7 @@ class MyApp extends StatelessWidget {
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
+        initialRoute: AppRoute.authSwitch.fullPath,
         theme: Themes.light,
         darkTheme: Themes.dark,
         routes: routes,
@@ -98,7 +100,7 @@ class MyApp extends StatelessWidget {
           return supportedLocales.first;
         },
         title: appName,
-        home: AuthSwitch(),
+        // home: AuthSwitch(),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,6 +72,7 @@ class MyApp extends StatelessWidget {
         theme: Themes.light,
         darkTheme: Themes.dark,
         routes: routes,
+        onGenerateRoute: onGenerateRoute,
         supportedLocales: [
           const Locale('en', 'US'),
           const Locale('ko', 'KR'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,6 @@ import 'package:wecount/utils/constatns.dart';
 import 'package:wecount/utils/routes.dart';
 import 'package:wecount/utils/themes.dart';
 
-import './navigations/auth_switch.dart' show AuthSwitch;
 import './utils/localization.dart';
 
 void main() async {
@@ -70,21 +69,8 @@ class MyApp extends StatelessWidget {
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        initialRoute: AppRoute.authSwitch.fullPath,
         theme: Themes.light,
         darkTheme: Themes.dark,
-        routes: routes,
-        onGenerateRoute: onGenerateRoute,
-        supportedLocales: [
-          const Locale('en', 'US'),
-          const Locale('ko', 'KR'),
-        ],
-        localizationsDelegates: [
-          const LocalizationDelegate(supportedLocales: ['en', 'ko']),
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
         localeResolutionCallback:
             (Locale? locale, Iterable<Locale> supportedLocales) {
           if (locale == null) {
@@ -99,8 +85,20 @@ class MyApp extends StatelessWidget {
           }
           return supportedLocales.first;
         },
+        localizationsDelegates: [
+          const LocalizationDelegate(supportedLocales: ['en', 'ko']),
+          GlobalMaterialLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: [
+          const Locale('en', 'US'),
+          const Locale('ko', 'KR'),
+        ],
+        initialRoute: AppRoute.authSwitch.fullPath,
+        routes: routes,
+        onGenerateRoute: onGenerateRoute,
         title: appName,
-        // home: AuthSwitch(),
       ),
     );
   }

--- a/lib/navigations/auth_switch.dart
+++ b/lib/navigations/auth_switch.dart
@@ -10,7 +10,7 @@ import 'package:wecount/services/database.dart';
 import 'package:wecount/utils/localization.dart';
 
 class AuthSwitch extends StatelessWidget {
-  static const String name = '/auth_switch';
+  static const String name = '/auth-switch';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/navigations/auth_switch.dart
+++ b/lib/navigations/auth_switch.dart
@@ -10,7 +10,7 @@ import 'package:wecount/services/database.dart';
 import 'package:wecount/utils/localization.dart';
 
 class AuthSwitch extends StatelessWidget {
-  static const String name = '/auth-switch';
+  const AuthSwitch({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -9,7 +9,7 @@ import 'package:wecount/screens/home_statistic/home_statistic.dart'
 import 'package:wecount/screens/home_setting.dart' show HomeSetting;
 
 class HomeTab extends StatefulWidget {
-  static const String name = '/home_tab';
+  static const String name = '/home-tab';
 
   HomeTab({Key? key}) : super(key: key);
 

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -25,6 +25,7 @@ class _HomeTabState extends State<HomeTab> {
     String _title = Provider.of<CurrentLedger>(context).getTitle() ?? '';
 
     return Scaffold(
+      // appBar: AppBar(),
       body: Stack(
         children: <Widget>[
           Offstage(

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -9,9 +9,7 @@ import 'package:wecount/screens/home_statistic/home_statistic.dart'
 import 'package:wecount/screens/home_setting.dart' show HomeSetting;
 
 class HomeTab extends StatefulWidget {
-  static const String name = '/home-tab';
-
-  HomeTab({Key? key}) : super(key: key);
+  const HomeTab({Key? key}) : super(key: key);
 
   @override
   _HomeTabState createState() => _HomeTabState();

--- a/lib/screens/category_add.dart
+++ b/lib/screens/category_add.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:wecount/models/category.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/edit_text_box.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/db_helper.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 
 class CategoryAdd extends StatefulWidget {
@@ -36,7 +36,7 @@ class _CategoryAddState extends State<CategoryAdd> {
         return;
       }
       if (_selectedIconIndex == null) {
-        General.instance.showSingleDialog(
+        navigation.showSingleDialog(
           context,
           title: Text(_localization.trans('ERROR')!),
           content: Text(_localization.trans('ERROR_CATEGORY_ICON')!),

--- a/lib/screens/find_pw.dart
+++ b/lib/screens/find_pw.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/edit_text.dart' show EditText;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/validator.dart' show Validator;
@@ -10,7 +10,7 @@ import 'package:wecount/utils/validator.dart' show Validator;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 
 class FindPw extends StatefulWidget {
-  static const String name = '/find_pw';
+  static const String name = '/find-pw';
 
   FindPw({Key? key}) : super(key: key);
 
@@ -38,7 +38,7 @@ class _FindPwState extends State<FindPw> {
 
     try {
       await _auth.sendPasswordResetEmail(email: _email);
-      General.instance.showSingleDialog(
+      navigation.showSingleDialog(
         context,
         title: Text(_localization!.trans('SUCCESS')!),
         content: Text(_localization!.trans('PASSWORD_RESET_LINK_SENT')!),

--- a/lib/screens/find_pw.dart
+++ b/lib/screens/find_pw.dart
@@ -10,9 +10,7 @@ import 'package:wecount/utils/validator.dart' show Validator;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 
 class FindPw extends StatefulWidget {
-  static const String name = '/find-pw';
-
-  FindPw({Key? key}) : super(key: key);
+  const FindPw({Key? key}) : super(key: key);
 
   @override
   _FindPwState createState() => _FindPwState();

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -50,7 +50,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () => navigation.push(context, Ledgers.name),
+                  onPressed: () => navigation.push(context, 'ledgers'),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,
@@ -63,7 +63,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
                   onPressed: () =>
-                      Navigator.of(context).pushNamed(LedgerItemEdit.name),
+                      Navigator.of(context).pushNamed("/ledger-item-edit"),
                   child: Icon(
                     Icons.add,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -4,6 +4,7 @@ import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/screens/ledger_item_edit.dart';
 import 'package:wecount/screens/ledgers.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/widgets/home_list_item.dart';
 import 'package:wecount/types/color.dart';
@@ -50,7 +51,8 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () => navigation.push(context, 'ledgers'),
+                  onPressed: () =>
+                      navigation.push(context, AppRoute.ledgers.fullPath),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,
@@ -62,8 +64,8 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () =>
-                      Navigator.of(context).pushNamed("/ledger-item-edit"),
+                  onPressed: () => Navigator.of(context)
+                      .pushNamed(AppRoute.ledgerItemEdit.fullPath),
                   child: Icon(
                     Icons.add,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -3,6 +3,7 @@ import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/screens/ledger_item_edit.dart';
 import 'package:wecount/screens/ledgers.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/widgets/home_list_item.dart';
 import 'package:wecount/types/color.dart';
@@ -10,7 +11,6 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:flutter/material.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/widgets/home_header.dart' show HomeHeaderExpanded;
 import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart'
     show CalendarCarousel;
@@ -50,8 +50,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () => General.instance
-                      .navigateScreenNamed(context, Ledgers.name),
+                  onPressed: () => navigation.push(context, Ledgers.name),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -23,7 +23,7 @@ import 'package:provider/provider.dart';
 class HomeCalendar extends StatefulWidget {
   HomeCalendar({
     Key? key,
-    this.title = '2017 Bookoo',
+    this.title = '2022 WeCount',
   }) : super(key: key);
   final String title;
 
@@ -52,7 +52,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
                   onPressed: () =>
-                      navigation.push(context, AppRoute.ledgers.fullPath),
+                      navigation.push(context, AppRoute.ledgers.path),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -38,7 +38,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
         : ColorType.DUSK;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: CustomScrollView(
         slivers: <Widget>[
           HomeHeaderExpanded(

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -3,6 +3,7 @@ import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/home_header_search.dart' show HomeHeaderSearch;
 import 'package:wecount/models/category.dart';
@@ -295,7 +296,7 @@ class _HomeListState extends State<HomeList> {
         : ColorType.DUSK;
 
     Function onAddLedgerList =
-        () => navigation.push(context, 'ledger-item-edit');
+        () => navigation.push(context, AppRoute.ledgerItemEdit.fullPath);
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -1,7 +1,10 @@
+import 'package:flat_list/flat_list.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/models/user.dart';
+import 'package:wecount/utils/logger.dart';
 
 import 'package:wecount/widgets/home_header_search.dart' show HomeHeaderSearch;
 import 'package:wecount/models/category.dart';
@@ -298,17 +301,19 @@ class _HomeListState extends State<HomeList> {
         General.instance.navigateScreenNamed(context, '/ledger_item_edit');
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
+        toolbarHeight: 100,
         automaticallyImplyLeading: false,
         titleSpacing: 0.0,
+        backgroundColor: Asset.Colors.getColor(color),
         title: HomeHeaderSearch(
           color: Asset.Colors.getColor(color),
           margin: EdgeInsets.only(left: 20.0),
           textEditingController: textEditingController,
           actions: <Widget>[
             Container(
-              width: 56.0,
+              width: 50.0,
               child: RawMaterialButton(
                 padding: EdgeInsets.all(0.0),
                 shape: CircleBorder(),
@@ -325,8 +330,25 @@ class _HomeListState extends State<HomeList> {
       body: SafeArea(
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: 16),
-          child: CustomScrollView(
-            slivers: _renderList(context),
+          child: FlatList(
+            data: _listData,
+            buildItem: (item, index) {
+              var section = _listData[index];
+              var headerDate = section['date'];
+              var ledgerItems = section['ledgerItems'];
+              return Column(
+                children: [
+                  _renderListHeader(headerDate),
+                  ...ledgerItems
+                      .map<Widget>(
+                        (val) => HomeListItem(
+                          ledgerItem: val,
+                        ),
+                      )
+                      .toList()
+                ],
+              );
+            },
           ),
         ),
       ),

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -295,9 +295,6 @@ class _HomeListState extends State<HomeList> {
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;
 
-    Function onAddLedgerList =
-        () => navigation.push(context, AppRoute.ledgerItemEdit.fullPath);
-
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
@@ -306,23 +303,12 @@ class _HomeListState extends State<HomeList> {
         titleSpacing: 0.0,
         backgroundColor: Asset.Colors.getColor(color),
         title: HomeHeaderSearch(
+          onPressAdd: () =>
+              navigation.push(context, AppRoute.ledgerItemEdit.path),
+          onPressDelete: () => textEditingController.clear(),
           color: Asset.Colors.getColor(color),
           margin: EdgeInsets.only(left: 20.0),
           textEditingController: textEditingController,
-          actions: <Widget>[
-            Container(
-              width: 50.0,
-              child: RawMaterialButton(
-                padding: EdgeInsets.all(0.0),
-                shape: CircleBorder(),
-                onPressed: onAddLedgerList as void Function()?,
-                child: Icon(
-                  Icons.add,
-                  color: Colors.white,
-                ),
-              ),
-            ),
-          ],
         ),
       ),
       body: SafeArea(

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -295,7 +295,7 @@ class _HomeListState extends State<HomeList> {
         : ColorType.DUSK;
 
     Function onAddLedgerList =
-        () => navigation.push(context, 'ledger_item_edit');
+        () => navigation.push(context, 'ledger-item-edit');
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -326,10 +326,11 @@ class _HomeListState extends State<HomeList> {
       ),
       body: SafeArea(
         child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16),
-            child: CustomScrollView(
-              slivers: _renderList(context),
-            )),
+          padding: EdgeInsets.symmetric(horizontal: 16),
+          child: CustomScrollView(
+            slivers: _renderList(context),
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -1,17 +1,14 @@
-import 'package:flat_list/flat_list.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/models/user.dart';
-import 'package:wecount/utils/logger.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/home_header_search.dart' show HomeHeaderSearch;
 import 'package:wecount/models/category.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/widgets/home_list_item.dart';
 
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:intl/intl.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
@@ -297,8 +294,8 @@ class _HomeListState extends State<HomeList> {
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;
 
-    Function onAddLedgerList = () =>
-        General.instance.navigateScreenNamed(context, '/ledger_item_edit');
+    Function onAddLedgerList =
+        () => navigation.push(context, 'ledger_item_edit');
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -329,28 +326,10 @@ class _HomeListState extends State<HomeList> {
       ),
       body: SafeArea(
         child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 16),
-          child: FlatList(
-            data: _listData,
-            buildItem: (item, index) {
-              var section = _listData[index];
-              var headerDate = section['date'];
-              var ledgerItems = section['ledgerItems'];
-              return Column(
-                children: [
-                  _renderListHeader(headerDate),
-                  ...ledgerItems
-                      .map<Widget>(
-                        (val) => HomeListItem(
-                          ledgerItem: val,
-                        ),
-                      )
-                      .toList()
-                ],
-              );
-            },
-          ),
-        ),
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            child: CustomScrollView(
+              slivers: _renderList(context),
+            )),
       ),
     );
   }

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -1,6 +1,4 @@
 import 'package:wecount/providers/current_ledger.dart';
-import 'package:wecount/screens/setting_currency.dart';
-import 'package:wecount/screens/setting_excel.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -42,8 +40,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () =>
-            navigation.push(context, AppRoute.settingCurrency.fullPath),
+        onTap: () => navigation.push(context, AppRoute.settingCurrency.path),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -53,7 +50,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, AppRoute.settingExcel.fullPath),
+        onTap: () => navigation.push(context, AppRoute.settingExcel.path),
       ),
     ];
 

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -41,7 +41,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, SettingCurrency.name),
+        onTap: () => navigation.push(context, "setting_currency"),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -51,7 +51,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, SettingExcel.name),
+        onTap: () => navigation.push(context, "setting-excel"),
       ),
     ];
 

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -64,7 +64,7 @@ class _HomeSettingState extends State<HomeSetting> {
         color: Asset.Colors.getColor(color),
         fontColor: Colors.white,
       ),
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Column(
           children: <Widget>[

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -5,6 +5,7 @@ import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import '../utils/asset.dart' as Asset;
 import '../utils/localization.dart' show Localization;
@@ -41,7 +42,8 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, "setting_currency"),
+        onTap: () =>
+            navigation.push(context, AppRoute.settingCurrency.fullPath),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -51,7 +53,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, "setting-excel"),
+        onTap: () => navigation.push(context, AppRoute.settingExcel.fullPath),
       ),
     ];
 

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -4,8 +4,8 @@ import 'package:wecount/screens/setting_excel.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:wecount/utils/navigation.dart';
 
-import '../utils/general.dart' show General;
 import '../utils/asset.dart' as Asset;
 import '../utils/localization.dart' show Localization;
 
@@ -41,8 +41,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () =>
-            General.instance.navigateScreenNamed(context, SettingCurrency.name),
+        onTap: () => navigation.push(context, SettingCurrency.name),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -52,8 +51,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () =>
-            General.instance.navigateScreenNamed(context, SettingExcel.name),
+        onTap: () => navigation.push(context, SettingExcel.name),
       ),
     ];
 

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -45,7 +45,7 @@ class HomeStatistic extends StatelessWidget {
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
               onPressed: () =>
-                  navigation.push(context, AppRoute.ledgerItemEdit.fullPath),
+                  navigation.push(context, AppRoute.ledgerItemEdit.path),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -2,6 +2,7 @@ import 'package:wecount/mocks/home_statistic.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/screens/home_statistic/functions.dart';
 
@@ -43,7 +44,8 @@ class HomeStatistic extends StatelessWidget {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, 'ledger-item-edit'),
+              onPressed: () =>
+                  navigation.push(context, AppRoute.ledgerItemEdit.fullPath),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -43,7 +43,7 @@ class HomeStatistic extends StatelessWidget {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, 'ledger_item_edit'),
+              onPressed: () => navigation.push(context, 'ledger-item-edit'),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -1,6 +1,7 @@
 import 'package:wecount/mocks/home_statistic.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/screens/home_statistic/functions.dart';
 
@@ -10,7 +11,6 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart';
 import 'package:flutter/material.dart';
 
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/widgets/home_header.dart' show renderHomeAppBar;
 import 'package:pie_chart/pie_chart.dart' show PieChart;
 // import 'package:month_picker_dialog/month_picker_dialog.dart';
@@ -43,8 +43,7 @@ class HomeStatistic extends StatelessWidget {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => General.instance
-                  .navigateScreenNamed(context, '/ledger_item_edit'),
+              onPressed: () => navigation.push(context, 'ledger_item_edit'),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -53,7 +53,7 @@ class HomeStatistic extends StatelessWidget {
           ),
         ],
       ),
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Container(
           child: Center(

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -6,7 +6,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/screens/sign_in.dart';
 import 'package:wecount/screens/sign_up.dart';
-import 'package:wecount/utils/logger.dart';
 import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
@@ -49,7 +48,6 @@ class Intro extends StatelessWidget {
         'updatedAt': FieldValue.serverTimestamp(),
         'deletedAt': null,
       });
-      print("here");
       _googleSignIn.signOut();
       Navigator.pushReplacementNamed(context, AuthSwitch.name);
     }

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -47,7 +47,7 @@ class Intro extends StatelessWidget {
         'deletedAt': null,
       });
       _googleSignIn.signOut();
-      Navigator.pushReplacementNamed(context, AppRoute.authSwitch.fullPath);
+      Navigator.pushReplacementNamed(context, AppRoute.authSwitch.path);
     }
   }
 
@@ -63,7 +63,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () => navigation.push(context, AppRoute.signIn.fullPath),
+        onPress: () => navigation.push(context, AppRoute.signIn.path),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -80,7 +80,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () => navigation.push(context, AppRoute.signUp.fullPath),
+          onPressed: () => navigation.push(context, AppRoute.signUp.path),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -65,7 +65,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () => navigation.push(context, SignIn.name),
+        onPress: () => navigation.push(context, 'sign-in'),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -82,7 +82,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () => navigation.push(context, SignUp.name),
+          onPressed: () => navigation.push(context, 'sign-up'),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/screens/sign_in.dart';
 import 'package:wecount/screens/sign_up.dart';
+import 'package:wecount/utils/logger.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/asset.dart' as Asset;
@@ -39,7 +40,6 @@ class Intro extends StatelessWidget {
       UserCredential auth =
           await FirebaseAuth.instance.signInWithCredential(credential);
       User user = auth.user!;
-
       await FirebaseFirestore.instance.collection('users').doc(user.uid).set({
         'email': user.email,
         'displayName': user.displayName,
@@ -49,7 +49,7 @@ class Intro extends StatelessWidget {
         'updatedAt': FieldValue.serverTimestamp(),
         'deletedAt': null,
       });
-
+      print("here");
       _googleSignIn.signOut();
       Navigator.pushReplacementNamed(context, AuthSwitch.name);
     }

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -7,10 +7,10 @@ import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/screens/sign_in.dart';
 import 'package:wecount/screens/sign_up.dart';
 import 'package:wecount/utils/logger.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/asset.dart' as Asset;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -23,7 +23,7 @@ class Intro extends StatelessWidget {
       scopes: ['email', 'https://www.googleapis.com/auth/contacts.readonly'],
     );
 
-    General.instance.showDialogSpinner(
+    navigation.showDialogSpinner(
       context,
       text: Localization.of(context)!.trans('SIGNING_IN_WITH_GOOGLE'),
     );
@@ -67,8 +67,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () =>
-            General.instance.navigateScreenNamed(context, SignIn.name),
+        onPress: () => navigation.push(context, SignIn.name),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -85,8 +84,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () =>
-              General.instance.navigateScreenNamed(context, SignUp.name),
+          onPressed: () => navigation.push(context, SignUp.name),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -3,10 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:wecount/navigations/auth_switch.dart';
-import 'package:wecount/screens/sign_in.dart';
-import 'package:wecount/screens/sign_up.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/asset.dart' as Asset;
@@ -15,7 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class Intro extends StatelessWidget {
-  static const String name = '/intro';
+  const Intro({Key? key}) : super(key: key);
 
   Future<void> _googleLogin(BuildContext context) async {
     final GoogleSignIn _googleSignIn = GoogleSignIn(
@@ -49,7 +47,7 @@ class Intro extends StatelessWidget {
         'deletedAt': null,
       });
       _googleSignIn.signOut();
-      Navigator.pushReplacementNamed(context, AuthSwitch.name);
+      Navigator.pushReplacementNamed(context, AppRoute.authSwitch.fullPath);
     }
   }
 
@@ -65,7 +63,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () => navigation.push(context, 'sign-in'),
+        onPress: () => navigation.push(context, AppRoute.signIn.fullPath),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -82,7 +80,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () => navigation.push(context, 'sign-up'),
+          onPressed: () => navigation.push(context, AppRoute.signUp.fullPath),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:wecount/screens/setting_currency.dart';
 import 'package:wecount/screens/members.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/member_horizontal_list.dart';
 import 'package:wecount/services/database.dart' show DatabaseService;
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
@@ -26,12 +27,10 @@ enum LedgerEditMode {
 }
 
 class LedgerEdit extends StatefulWidget {
-  static const String name = '/ledger-edit';
-
   final Ledger? ledger;
   final LedgerEditMode mode;
 
-  LedgerEdit({
+  const LedgerEdit({
     Key? key,
     this.ledger,
     this.mode = LedgerEditMode.ADD,
@@ -62,7 +61,7 @@ class _LedgerEditState extends State<LedgerEdit> {
   void _onPressCurrency() async {
     var _result = await navigation.navigate(
       context,
-      'setting-currency',
+      AppRoute.settingCurrency.fullPath,
       arguments: SettingCurrencyArguments(
         selectedCurrency: _ledger!.currency.currency,
       ),
@@ -305,7 +304,7 @@ class _LedgerEditState extends State<LedgerEdit> {
                       widget.ledger != null ? widget.ledger!.memberIds : [],
                   onSeeAllPressed: () => navigation.navigate(
                     context,
-                    'members',
+                    AppRoute.members.fullPath,
                     arguments: MembersArguments(ledger: widget.ledger),
                   ),
                 ),

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -61,7 +61,7 @@ class _LedgerEditState extends State<LedgerEdit> {
   void _onPressCurrency() async {
     var _result = await navigation.navigate(
       context,
-      AppRoute.settingCurrency.fullPath,
+      AppRoute.settingCurrency.path,
       arguments: SettingCurrencyArguments(
         selectedCurrency: _ledger!.currency.currency,
       ),
@@ -304,7 +304,7 @@ class _LedgerEditState extends State<LedgerEdit> {
                       widget.ledger != null ? widget.ledger!.memberIds : [],
                   onSeeAllPressed: () => navigation.navigate(
                     context,
-                    AppRoute.members.fullPath,
+                    AppRoute.members.path,
                     arguments: MembersArguments(ledger: widget.ledger),
                   ),
                 ),

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -2,10 +2,10 @@ import 'package:wecount/providers/current_ledger.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/screens/setting_currency.dart';
 import 'package:wecount/screens/members.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/member_horizontal_list.dart';
 import 'package:wecount/services/database.dart' show DatabaseService;
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/models/currency.dart';
@@ -13,13 +13,20 @@ import 'package:wecount/models/ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:provider/provider.dart';
 
+class LedgerEditArguments {
+  final Ledger? ledger;
+  final LedgerEditMode mode;
+
+  LedgerEditArguments({this.ledger, this.mode = LedgerEditMode.ADD});
+}
+
 enum LedgerEditMode {
   ADD,
   UPDATE,
 }
 
 class LedgerEdit extends StatefulWidget {
-  static const String name = '/ledger_edit';
+  static const String name = '/ledger-edit';
 
   final Ledger? ledger;
   final LedgerEditMode mode;
@@ -53,12 +60,11 @@ class _LedgerEditState extends State<LedgerEdit> {
   }
 
   void _onPressCurrency() async {
-    var _result = await General.instance.navigateScreen(
+    var _result = await navigation.navigate(
       context,
-      MaterialPageRoute(
-        builder: (BuildContext context) => SettingCurrency(
-          selectedCurrency: _ledger!.currency.currency,
-        ),
+      'setting-currency',
+      arguments: SettingCurrencyArguments(
+        selectedCurrency: _ledger!.currency.currency,
       ),
     );
 
@@ -120,7 +126,7 @@ class _LedgerEditState extends State<LedgerEdit> {
 
     var _localization = Localization.of(context)!;
 
-    General.instance.showSingleDialog(
+    navigation.showSingleDialog(
       context,
       title: Text(_localization.trans('ERROR')!),
       content: Text(_localization.trans('SHOULD_TRANSFER_OWNERSHIP')!),
@@ -297,13 +303,10 @@ class _LedgerEditState extends State<LedgerEdit> {
                   showAddBtn: true,
                   memberIds:
                       widget.ledger != null ? widget.ledger!.memberIds : [],
-                  onSeeAllPressed: () => General.instance.navigateScreen(
+                  onSeeAllPressed: () => navigation.navigate(
                     context,
-                    MaterialPageRoute(
-                      builder: (BuildContext context) => Members(
-                        ledger: widget.ledger,
-                      ),
-                    ),
+                    'members',
+                    arguments: MembersArguments(ledger: widget.ledger),
                   ),
                 ),
               ],

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -636,7 +636,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
           ),
         ],
       ),
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -655,7 +655,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
                   insets: EdgeInsets.symmetric(horizontal: 8),
                   // insets: EdgeInsets.fromLTRB(50.0, 0.0, 50.0, 40.0),
                 ),
-                indicatorColor: Theme.of(context).backgroundColor,
+                indicatorColor: Theme.of(context).colorScheme.background,
                 labelColor: Theme.of(context).textTheme.displayLarge!.color,
                 labelStyle: TextStyle(
                   fontSize: 20,

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -6,18 +6,18 @@ import 'package:wecount/models/ledger_item.dart' show LedgerItem;
 import 'package:wecount/models/photo.dart' show Photo;
 import 'package:wecount/screens/category_add.dart';
 import 'package:wecount/screens/location_view.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/category_list.dart';
 import 'package:wecount/widgets/gallery.dart' show Gallery;
 import 'package:wecount/widgets/header.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/db_helper.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/logger.dart';
 
 class LedgerItemEdit extends StatefulWidget {
-  static const String name = '/ledger_item_edit';
+  static const String name = '/ledger-item-edit';
 
   LedgerItemEdit({
     Key? key,
@@ -111,12 +111,8 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
     void onLocationPressed({
       CategoryType categoryType = CategoryType.CONSUME,
     }) async {
-      Map<String, dynamic>? result = await (General.instance.navigateScreen(
-        context,
-        MaterialPageRoute(
-          builder: (BuildContext context) => LocationView(),
-        ),
-      ));
+      Map<String, dynamic>? result =
+          await (navigation.navigate(context, 'location-view'));
 
       if (result == null) return;
 

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -5,8 +5,8 @@ import 'package:wecount/models/category.dart';
 import 'package:wecount/models/ledger_item.dart' show LedgerItem;
 import 'package:wecount/models/photo.dart' show Photo;
 import 'package:wecount/screens/category_add.dart';
-import 'package:wecount/screens/location_view.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/category_list.dart';
 import 'package:wecount/widgets/gallery.dart' show Gallery;
 import 'package:wecount/widgets/header.dart';
@@ -17,9 +17,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/logger.dart';
 
 class LedgerItemEdit extends StatefulWidget {
-  static const String name = '/ledger-item-edit';
-
-  LedgerItemEdit({
+  const LedgerItemEdit({
     Key? key,
     this.title = '',
   }) : super(key: key);
@@ -112,7 +110,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
       CategoryType categoryType = CategoryType.CONSUME,
     }) async {
       Map<String, dynamic>? result =
-          await (navigation.navigate(context, 'location-view'));
+          await (navigation.navigate(context, AppRoute.locationView.fullPath));
 
       if (result == null) return;
 

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -110,7 +110,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
       CategoryType categoryType = CategoryType.CONSUME,
     }) async {
       Map<String, dynamic>? result =
-          await (navigation.navigate(context, AppRoute.locationView.fullPath));
+          await (navigation.navigate(context, AppRoute.locationView.path));
 
       if (result == null) return;
 

--- a/lib/screens/ledger_view.dart
+++ b/lib/screens/ledger_view.dart
@@ -8,8 +8,14 @@ import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/types/color.dart';
 
+class LedgerViewArguments {
+  final Ledger? ledger;
+
+  LedgerViewArguments({this.ledger});
+}
+
 class LedgerView extends StatefulWidget {
-  static const String name = '/ledger_view';
+  static const String name = '/ledger-view';
 
   final Ledger? ledger;
   const LedgerView({

--- a/lib/screens/ledger_view.dart
+++ b/lib/screens/ledger_view.dart
@@ -15,8 +15,6 @@ class LedgerViewArguments {
 }
 
 class LedgerView extends StatefulWidget {
-  static const String name = '/ledger-view';
-
   final Ledger? ledger;
   const LedgerView({
     Key? key,

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -55,7 +55,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onAddLedgerPressed() {
-      navigation.push(context, '/ledger_edit');
+      navigation.push(context, '/ledger-edit');
     }
 
     return Scaffold(

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -60,7 +60,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -31,11 +31,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      navigation.push(context, Setting.name);
+      navigation.push(context, 'setting');
     }
 
     void onProfilePressed() {
-      navigation.push(context, ProfileMy.name);
+      navigation.push(context, 'profile-my');
     }
 
     void onLedgerPressed(Ledger item) {

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -1,11 +1,10 @@
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:wecount/screens/profile_my.dart';
-import 'package:wecount/screens/setting.dart';
 
 import 'package:wecount/services/database.dart' show DatabaseService;
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/screens/ledger_edit.dart';
 import 'package:wecount/screens/ledger_view.dart';
@@ -17,9 +16,7 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:provider/provider.dart' show Provider;
 
 class Ledgers extends StatefulWidget {
-  static const String name = '/ledgers';
-
-  Ledgers({Key? key}) : super(key: key);
+  const Ledgers({Key? key}) : super(key: key);
 
   @override
   _LedgersState createState() => _LedgersState();
@@ -31,11 +28,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      navigation.push(context, 'setting');
+      navigation.push(context, AppRoute.setting.fullPath);
     }
 
     void onProfilePressed() {
-      navigation.push(context, 'profile-my');
+      navigation.push(context, AppRoute.profileMy.fullPath);
     }
 
     void onLedgerPressed(Ledger item) {
@@ -47,7 +44,9 @@ class _LedgersState extends State<Ledgers> {
     void onLedgerMorePressed(Ledger item) {
       navigation.navigate(
         context,
-        item.ownerId != user.uid ? 'ledger-view' : 'ledger-edit',
+        item.ownerId != user.uid
+            ? AppRoute.ledgerView.fullPath
+            : AppRoute.ledgerEdit.fullPath,
         arguments: item.ownerId != user.uid
             ? LedgerViewArguments(ledger: item)
             : LedgerEditArguments(ledger: item, mode: LedgerEditMode.UPDATE),
@@ -55,7 +54,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onAddLedgerPressed() {
-      navigation.push(context, '/ledger-edit');
+      navigation.push(context, AppRoute.ledgerEdit.fullPath);
     }
 
     return Scaffold(

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -5,6 +5,7 @@ import 'package:wecount/screens/profile_my.dart';
 import 'package:wecount/screens/setting.dart';
 
 import 'package:wecount/services/database.dart' show DatabaseService;
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/screens/ledger_edit.dart';
 import 'package:wecount/screens/ledger_view.dart';
@@ -13,7 +14,6 @@ import 'package:wecount/widgets/ledger_list_item.dart' show LedgerListItem;
 import 'package:wecount/models/ledger.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
-import 'package:wecount/utils/general.dart';
 import 'package:provider/provider.dart' show Provider;
 
 class Ledgers extends StatefulWidget {
@@ -31,11 +31,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      General.instance.navigateScreenNamed(context, Setting.name);
+      navigation.push(context, Setting.name);
     }
 
     void onProfilePressed() {
-      General.instance.navigateScreenNamed(context, ProfileMy.name);
+      navigation.push(context, ProfileMy.name);
     }
 
     void onLedgerPressed(Ledger item) {
@@ -45,18 +45,17 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onLedgerMorePressed(Ledger item) {
-      General.instance.navigateScreen(
+      navigation.navigate(
         context,
-        MaterialPageRoute(
-          builder: (BuildContext context) => item.ownerId != user.uid
-              ? LedgerView(ledger: item)
-              : LedgerEdit(ledger: item, mode: LedgerEditMode.UPDATE),
-        ),
+        item.ownerId != user.uid ? 'ledger-view' : 'ledger-edit',
+        arguments: item.ownerId != user.uid
+            ? LedgerViewArguments(ledger: item)
+            : LedgerEditArguments(ledger: item, mode: LedgerEditMode.UPDATE),
       );
     }
 
     void onAddLedgerPressed() {
-      General.instance.navigateScreenNamed(context, '/ledger_edit');
+      navigation.push(context, '/ledger_edit');
     }
 
     return Scaffold(

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -28,11 +28,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      navigation.push(context, AppRoute.setting.fullPath);
+      navigation.push(context, AppRoute.setting.path);
     }
 
     void onProfilePressed() {
-      navigation.push(context, AppRoute.profileMy.fullPath);
+      navigation.push(context, AppRoute.profileMy.path);
     }
 
     void onLedgerPressed(Ledger item) {
@@ -45,8 +45,8 @@ class _LedgersState extends State<Ledgers> {
       navigation.navigate(
         context,
         item.ownerId != user.uid
-            ? AppRoute.ledgerView.fullPath
-            : AppRoute.ledgerEdit.fullPath,
+            ? AppRoute.ledgerView.path
+            : AppRoute.ledgerEdit.path,
         arguments: item.ownerId != user.uid
             ? LedgerViewArguments(ledger: item)
             : LedgerEditArguments(ledger: item, mode: LedgerEditMode.UPDATE),
@@ -54,7 +54,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onAddLedgerPressed() {
-      navigation.push(context, AppRoute.ledgerEdit.fullPath);
+      navigation.push(context, AppRoute.ledgerEdit.path);
     }
 
     return Scaffold(

--- a/lib/screens/line_graph.dart
+++ b/lib/screens/line_graph.dart
@@ -77,7 +77,7 @@ class _LineGraphState extends State<LineGraph> {
     /// Render
     return Scaffold(
       // resizeToAvoidBottomPadding: false,
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/line_graph.dart
+++ b/lib/screens/line_graph.dart
@@ -8,6 +8,14 @@ import '../widgets/header.dart' show renderHeaderBack;
 
 import 'package:intl/intl.dart' show DateFormat, NumberFormat;
 
+class LineGraphArguments {
+  final String title;
+  final String year;
+  final double? price;
+
+  LineGraphArguments(this.title, this.year, this.price);
+}
+
 double getPriceSum(List<LedgerItem> items) {
   double sum = 0;
   items.forEach((item) {
@@ -18,15 +26,13 @@ double getPriceSum(List<LedgerItem> items) {
 
 /// main
 class LineGraph extends StatefulWidget {
-  static const String name = '/line_graph';
+  static const String name = '/line-graph';
 
-  LineGraph({
-    Key? key,
-    this.title = '',
-    this.year = '2019',
-  }) : super(key: key);
+  LineGraph({Key? key, this.title = '', this.year = '2019', this.price = 0.0})
+      : super(key: key);
   final String title;
   final String year;
+  final double price;
 
   @override
   _LineGraphState createState() => _LineGraphState();
@@ -89,7 +95,8 @@ class _LineGraphState extends State<LineGraph> {
           children: <Widget>[
             headerAlign(
               child: Text(
-                _localization.trans('CAFE')!,
+                '${widget.title}',
+                // _localization.trans('CAFE')!,
                 style: TextStyle(
                   fontSize: 30,
                   color: Theme.of(context).textTheme.displayLarge!.color,
@@ -108,7 +115,7 @@ class _LineGraphState extends State<LineGraph> {
                 : BottomListTitle(
                     date: DateFormat('y')
                         .format(DateTime(int.parse(widget.year))),
-                    price: this._priceSum),
+                    price: widget.price),
             Divider(
               color: Colors.grey,
               height: 1,

--- a/lib/screens/line_graph.dart
+++ b/lib/screens/line_graph.dart
@@ -26,9 +26,8 @@ double getPriceSum(List<LedgerItem> items) {
 
 /// main
 class LineGraph extends StatefulWidget {
-  static const String name = '/line-graph';
-
-  LineGraph({Key? key, this.title = '', this.year = '2019', this.price = 0.0})
+  const LineGraph(
+      {Key? key, this.title = '', this.year = '2019', this.price = 0.0})
       : super(key: key);
   final String title;
   final String year;

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -8,7 +8,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
 class LocationView extends StatefulWidget {
-  static const name = '/location-view';
+  const LocationView({Key? key}) : super(key: key);
 
   @override
   _LocationViewState createState() => _LocationViewState();

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -8,6 +8,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
 class LocationView extends StatefulWidget {
+  static const name = '/location-view';
+
   @override
   _LocationViewState createState() => _LocationViewState();
 }

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -110,7 +110,7 @@ class _LocationViewState extends State<LocationView> {
     return _center == null
         ? const LoadingIndicator()
         : Scaffold(
-            backgroundColor: Theme.of(context).backgroundColor,
+            backgroundColor: Theme.of(context).colorScheme.background,
             appBar: renderHeaderClose(
               context: context,
               brightness: Theme.of(context).brightness,

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -11,7 +11,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:local_auth/local_auth.dart';
 
 class LockAuth extends StatefulWidget {
-  static const String name = '/lock_auth';
+  static const String name = '/lock-auth';
 
   @override
   _LockAuthState createState() => _LockAuthState();

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -11,7 +11,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:local_auth/local_auth.dart';
 
 class LockAuth extends StatefulWidget {
-  static const String name = '/lock-auth';
+  const LockAuth({Key? key}) : super(key: key);
 
   @override
   _LockAuthState createState() => _LockAuthState();

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -129,7 +129,7 @@ class _LockAuthState extends State<LockAuth> {
     _screenSize = MediaQuery.of(context).size;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         context: context,
         iconColor: Theme.of(context).iconTheme.color,

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -7,7 +7,7 @@ import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
 import 'package:wecount/utils/localization.dart' show Localization;
 
 class LockRegister extends StatefulWidget {
-  static const String name = '/lock-register';
+  const LockRegister({Key? key}) : super(key: key);
 
   @override
   _LockRegisterState createState() => _LockRegisterState();

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -7,7 +7,7 @@ import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
 import 'package:wecount/utils/localization.dart' show Localization;
 
 class LockRegister extends StatefulWidget {
-  static const String name = '/lock_register';
+  static const String name = '/lock-register';
 
   @override
   _LockRegisterState createState() => _LockRegisterState();

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -81,7 +81,7 @@ class _LockRegisterState extends State<LockRegister> {
     _screenSize = MediaQuery.of(context).size;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         context: context,
         iconColor: Theme.of(context).textTheme.displayLarge!.color,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -36,7 +36,7 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, Setting.name),
+              onPressed: () => navigation.push(context, 'setting'),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,
@@ -87,7 +87,7 @@ class _MainEmptyState extends State<MainEmpty> {
                   ),
                 ),
               ),
-              onPress: () => Navigator.of(context).pushNamed(LedgerEdit.name),
+              onPress: () => Navigator.of(context).pushNamed("ledger-edit"),
               text: _localization.trans('ADD_LEDGER'),
               textStyle: TextStyle(
                 fontSize: 20,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -26,7 +26,7 @@ class _MainEmptyState extends State<MainEmpty> {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHomeAppBar(
         context: context,
         title: '',
@@ -47,7 +47,7 @@ class _MainEmptyState extends State<MainEmpty> {
         ],
       ),
       body: Container(
-        color: Theme.of(context).backgroundColor,
+        color: Theme.of(context).colorScheme.background,
         width: double.infinity,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -78,12 +78,14 @@ class _MainEmptyState extends State<MainEmpty> {
               backgroundColor: Colors.transparent,
               width: 160,
               height: 56,
-              shapeBorder: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(32),
-                side: BorderSide(
-                  color: Theme.of(context).textTheme.displayMedium!.color!,
-                  width: 1,
-                  style: BorderStyle.solid,
+              shapeBorder: MaterialStatePropertyAll<OutlinedBorder>(
+                RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(32),
+                  side: BorderSide(
+                    color: Theme.of(context).textTheme.displayMedium!.color!,
+                    width: 1,
+                    style: BorderStyle.solid,
+                  ),
                 ),
               ),
               onPress: () => Navigator.of(context).pushNamed(LedgerEdit.name),

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:wecount/screens/ledger_edit.dart';
 import 'package:wecount/screens/setting.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
 class MainEmpty extends StatefulWidget {
-  static const String name = '/main_empty';
+  static const String name = '/main-empty';
 
   MainEmpty({
     Key? key,
@@ -36,8 +36,7 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () =>
-                  General.instance.navigateScreenNamed(context, Setting.name),
+              onPressed: () => navigation.push(context, Setting.name),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -33,8 +33,7 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () =>
-                  navigation.push(context, AppRoute.setting.fullPath),
+              onPressed: () => navigation.push(context, AppRoute.setting.path),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:wecount/screens/ledger_edit.dart';
-import 'package:wecount/screens/setting.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/localization.dart' show Localization;
@@ -9,9 +8,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
 class MainEmpty extends StatefulWidget {
-  static const String name = '/main-empty';
-
-  MainEmpty({
+  const MainEmpty({
     Key? key,
     this.title = '',
   }) : super(key: key);
@@ -36,7 +33,8 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, 'setting'),
+              onPressed: () =>
+                  navigation.push(context, AppRoute.setting.fullPath),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,
@@ -87,7 +85,8 @@ class _MainEmptyState extends State<MainEmpty> {
                   ),
                 ),
               ),
-              onPress: () => Navigator.of(context).pushNamed("ledger-edit"),
+              onPress: () =>
+                  Navigator.of(context).pushNamed(AppRoute.ledgerEdit.fullPath),
               text: _localization.trans('ADD_LEDGER'),
               textStyle: TextStyle(
                 fontSize: 20,

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,4 +1,5 @@
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/edit_text.dart';
 import 'package:flutter/material.dart';
 
@@ -16,10 +17,8 @@ class MembersArguments {
 }
 
 class Members extends StatefulWidget {
-  static const String name = '/members';
-
   final Ledger? ledger;
-  Members({Key? key, this.ledger}) : super(key: key);
+  const Members({Key? key, this.ledger}) : super(key: key);
 
   @override
   _MembersState createState() => _MembersState();
@@ -197,7 +196,7 @@ class _MembersState extends State<Members> {
                 }, item.user.membership!.index);
               },
               onPressMember: () {
-                navigation.navigate(context, 'profile-peer',
+                navigation.navigate(context, AppRoute.profilePeer.fullPath,
                     arguments: ProfilePeerArguments(
                       user: item.user,
                     ));

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -110,7 +110,7 @@ class _MembersState extends State<Members> {
     var _localization = Localization.of(context)!;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -196,7 +196,7 @@ class _MembersState extends State<Members> {
                 }, item.user.membership!.index);
               },
               onPressMember: () {
-                navigation.navigate(context, AppRoute.profilePeer.fullPath,
+                navigation.navigate(context, AppRoute.profilePeer.path,
                     arguments: ProfilePeerArguments(
                       user: item.user,
                     ));

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,15 +1,23 @@
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/edit_text.dart';
 import 'package:flutter/material.dart';
 
 import 'package:wecount/screens/profile_peer.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/widgets/member_list_item.dart';
 import 'package:wecount/widgets/header.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/models/ledger.dart';
 import 'package:wecount/utils/localization.dart';
 
+class MembersArguments {
+  final Ledger? ledger;
+
+  MembersArguments({this.ledger});
+}
+
 class Members extends StatefulWidget {
+  static const String name = '/members';
+
   final Ledger? ledger;
   Members({Key? key, this.ledger}) : super(key: key);
 
@@ -181,7 +189,7 @@ class _MembersState extends State<Members> {
             return MemberListItem(
               user: item.user,
               onPressAuth: () {
-                General.instance.showMembershipDialog(context, (int? val) {
+                navigation.showMembershipDialog(context, (int? val) {
                   setState(() {
                     item.user.changeMemberShip(val!);
                   });
@@ -189,12 +197,9 @@ class _MembersState extends State<Members> {
                 }, item.user.membership!.index);
               },
               onPressMember: () {
-                General.instance.navigateScreen(
-                    context,
-                    MaterialPageRoute(
-                      builder: (BuildContext context) => ProfilePeer(
-                        user: item.user,
-                      ),
+                navigation.navigate(context, 'profile-peer',
+                    arguments: ProfilePeerArguments(
+                      user: item.user,
                     ));
               },
             );

--- a/lib/screens/photo_detail.dart
+++ b/lib/screens/photo_detail.dart
@@ -7,7 +7,27 @@ import 'package:flutter/material.dart';
 import 'package:wecount/models/photo.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 
+class PhotoDetailArguments {
+  final Photo? photo;
+  final String? photoUrl;
+  final bool canShare;
+  final Function? onPressDelete;
+  final Function? onPressShare;
+  final Function? onPressDownload;
+
+  PhotoDetailArguments({
+    this.photo,
+    this.photoUrl,
+    this.canShare = false,
+    this.onPressDelete,
+    this.onPressShare,
+    this.onPressDownload,
+  });
+}
+
 class PhotoDetail extends StatefulWidget {
+  static const String name = '/photo-detail';
+
   PhotoDetail({
     Key? key,
     this.photo,

--- a/lib/screens/photo_detail.dart
+++ b/lib/screens/photo_detail.dart
@@ -26,9 +26,7 @@ class PhotoDetailArguments {
 }
 
 class PhotoDetail extends StatefulWidget {
-  static const String name = '/photo-detail';
-
-  PhotoDetail({
+  const PhotoDetail({
     Key? key,
     this.photo,
     this.photoUrl,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -40,7 +40,7 @@ class _ProfileMyState extends State<ProfileMy> {
     var _user = Provider.of<FireAuth.User>(context);
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -2,17 +2,17 @@ import 'package:wecount/models/user.dart' show User;
 import 'package:wecount/services/database.dart';
 import 'package:firebase_auth/firebase_auth.dart' as FireAuth show User;
 import 'package:flutter/material.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/widgets/edit_text_box.dart' show EditTextBox;
 import 'package:wecount/widgets/profile_image_cam.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
 class ProfileMy extends StatefulWidget {
-  static const String name = '/profile_my';
+  static const String name = '/profile-my';
 
   @override
   _ProfileMyState createState() => _ProfileMyState();
@@ -23,7 +23,7 @@ class _ProfileMyState extends State<ProfileMy> {
   User? _profile;
 
   Future<void> _onUpdateProfile() async {
-    General.instance.showDialogSpinner(context);
+    navigation.showDialogSpinner(context);
 
     await DatabaseService().requestUpdateProfile(
       _profile,
@@ -86,15 +86,15 @@ class _ProfileMyState extends State<ProfileMy> {
                           ? _profile!.thumbURL
                           : _profile!.photoURL,
                       selectCamera: () async {
-                        var file = await General.instance
-                            .chooseImage(context: context, type: 'camera');
+                        var file = await navigation.chooseImage(
+                            context: context, type: 'camera');
                         if (file != null) {
                           setState(() => _imgFile = file);
                         }
                       },
                       selectGallery: () async {
-                        var file = await General.instance
-                            .chooseImage(context: context, type: 'gallery');
+                        var file = await navigation.chooseImage(
+                            context: context, type: 'gallery');
                         if (file != null) {
                           setState(() => _imgFile = file);
                         }

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -12,7 +12,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
 class ProfileMy extends StatefulWidget {
-  static const String name = '/profile-my';
+  const ProfileMy({Key? key}) : super(key: key);
 
   @override
   _ProfileMyState createState() => _ProfileMyState();

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -35,7 +35,7 @@ class _ProfilePeerState extends State<ProfilePeer> {
     Localization.of(context);
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -1,13 +1,20 @@
 import 'package:wecount/models/user.dart';
 import 'package:wecount/screens/photo_detail.dart';
 import 'package:flutter/material.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/widgets/edit_text_box.dart' show EditTextBox;
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 
+class ProfilePeerArguments {
+  final User user;
+
+  ProfilePeerArguments({required this.user});
+}
+
 class ProfilePeer extends StatefulWidget {
+  static const String name = '/profile-peer';
   final User user;
 
   ProfilePeer({
@@ -20,12 +27,11 @@ class ProfilePeer extends StatefulWidget {
 
 class _ProfilePeerState extends State<ProfilePeer> {
   void showImage(String photoUrl) async {
-    await General.instance.navigateScreen(
+    await navigation.navigate(
       context,
-      MaterialPageRoute(
-        builder: (BuildContext context) => PhotoDetail(
-          photoUrl: photoUrl,
-        ),
+      'photo-detail',
+      arguments: PhotoDetailArguments(
+        photoUrl: photoUrl,
       ),
     );
   }

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -2,6 +2,7 @@ import 'package:wecount/models/user.dart';
 import 'package:wecount/screens/photo_detail.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/widgets/edit_text_box.dart' show EditTextBox;
@@ -14,10 +15,8 @@ class ProfilePeerArguments {
 }
 
 class ProfilePeer extends StatefulWidget {
-  static const String name = '/profile-peer';
   final User user;
-
-  ProfilePeer({
+  const ProfilePeer({
     required this.user,
   });
 
@@ -29,7 +28,7 @@ class _ProfilePeerState extends State<ProfilePeer> {
   void showImage(String photoUrl) async {
     await navigation.navigate(
       context,
-      'photo-detail',
+      AppRoute.photoDetail.fullPath,
       arguments: PhotoDetailArguments(
         photoUrl: photoUrl,
       ),

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -28,7 +28,7 @@ class _ProfilePeerState extends State<ProfilePeer> {
   void showImage(String photoUrl) async {
     await navigation.navigate(
       context,
-      AppRoute.photoDetail.fullPath,
+      AppRoute.photoDetail.path,
       arguments: PhotoDetailArguments(
         photoUrl: photoUrl,
       ),

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -8,11 +8,11 @@ import 'package:wecount/screens/setting_faq.dart';
 import 'package:wecount/screens/setting_notification.dart';
 import 'package:wecount/screens/setting_opinion.dart';
 import 'package:wecount/screens/tutorial.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/setting_list_item.dart'
     show ListItem, LogoutItem, SettingItem, SettingListItem;
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart' show Localization;
 
@@ -62,7 +62,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await General.instance.navigateScreenNamed(context, LockRegister.name);
+    await navigation.push(context, LockRegister.name);
 
     setState(() {
       readLockPinFromSF();
@@ -70,8 +70,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result =
-        await General.instance.navigateScreenNamed(context, LockAuth.name);
+    final result = await navigation.push(context, LockAuth.name);
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -92,8 +91,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('ANNOUNCEMENT'),
-        onPressed: () => General.instance
-            .navigateScreenNamed(context, SettingAnnouncement.name),
+        onPressed: () => navigation.push(context, SettingAnnouncement.name),
       ),
       SettingItem(
         Icon(
@@ -102,8 +100,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () =>
-            General.instance.navigateScreenNamed(context, SettingOpinion.name),
+        onPressed: () => navigation.push(context, SettingOpinion.name),
       ),
       SettingItem(
         Icon(
@@ -112,8 +109,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () =>
-            General.instance.navigateScreenNamed(context, SettingFAQ.name),
+        onPressed: () => navigation.push(context, SettingFAQ.name),
       ),
       SettingItem(
         Icon(
@@ -122,8 +118,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('NOTIFICATION'),
-        onPressed: () => General.instance
-            .navigateScreenNamed(context, SettingNotification.name),
+        onPressed: () => navigation.push(context, SettingNotification.name),
       ),
       SettingItem(
         Icon(
@@ -145,8 +140,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          General.instance
-              .navigateScreenNamed(context, Tutorial.name, reset: true);
+          navigation.push(context, Tutorial.name, reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -56,7 +56,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await navigation.push(context, AppRoute.lockRegister.fullPath);
+    await navigation.push(context, AppRoute.lockRegister.path);
 
     setState(() {
       readLockPinFromSF();
@@ -64,7 +64,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result = await navigation.push(context, AppRoute.lockAuth.fullPath);
+    final result = await navigation.push(context, AppRoute.lockAuth.path);
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -86,7 +86,7 @@ class _SettingState extends State<Setting> {
         ),
         _localization.trans('ANNOUNCEMENT'),
         onPressed: () =>
-            navigation.push(context, AppRoute.settingAnnouncement.fullPath),
+            navigation.push(context, AppRoute.settingAnnouncement.path),
       ),
       SettingItem(
         Icon(
@@ -95,8 +95,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () =>
-            navigation.push(context, AppRoute.settingOpinion.fullPath),
+        onPressed: () => navigation.push(context, AppRoute.settingOpinion.path),
       ),
       SettingItem(
         Icon(
@@ -105,7 +104,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () => navigation.push(context, AppRoute.settingFAQ.fullPath),
+        onPressed: () => navigation.push(context, AppRoute.settingFAQ.path),
       ),
       SettingItem(
         Icon(
@@ -115,7 +114,7 @@ class _SettingState extends State<Setting> {
         ),
         _localization.trans('NOTIFICATION'),
         onPressed: () =>
-            navigation.push(context, AppRoute.settingNotification.fullPath),
+            navigation.push(context, AppRoute.settingNotification.path),
       ),
       SettingItem(
         Icon(
@@ -137,7 +136,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          navigation.push(context, AppRoute.tutorial.fullPath, reset: true);
+          navigation.push(context, AppRoute.tutorial.path, reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -1,14 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:wecount/screens/lock_auth.dart';
-import 'package:wecount/screens/lock_register.dart';
-import 'package:wecount/screens/setting_announcement.dart';
-import 'package:wecount/screens/setting_faq.dart';
-import 'package:wecount/screens/setting_notification.dart';
-import 'package:wecount/screens/setting_opinion.dart';
-import 'package:wecount/screens/tutorial.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/setting_list_item.dart'
     show ListItem, LogoutItem, SettingItem, SettingListItem;
@@ -19,7 +13,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 FirebaseAuth _auth = FirebaseAuth.instance;
 
 class Setting extends StatefulWidget {
-  static const String name = '/setting';
+  const Setting({Key? key}) : super(key: key);
 
   @override
   _SettingState createState() => _SettingState();
@@ -62,7 +56,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await navigation.push(context, "lock-register");
+    await navigation.push(context, AppRoute.lockRegister.fullPath);
 
     setState(() {
       readLockPinFromSF();
@@ -70,7 +64,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result = await navigation.push(context, "lock-auth");
+    final result = await navigation.push(context, AppRoute.lockAuth.fullPath);
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -91,7 +85,8 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('ANNOUNCEMENT'),
-        onPressed: () => navigation.push(context, "setting-announcement"),
+        onPressed: () =>
+            navigation.push(context, AppRoute.settingAnnouncement.fullPath),
       ),
       SettingItem(
         Icon(
@@ -100,7 +95,8 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () => navigation.push(context, "setting-opinion"),
+        onPressed: () =>
+            navigation.push(context, AppRoute.settingOpinion.fullPath),
       ),
       SettingItem(
         Icon(
@@ -109,7 +105,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () => navigation.push(context, "setting-faq"),
+        onPressed: () => navigation.push(context, AppRoute.settingFAQ.fullPath),
       ),
       SettingItem(
         Icon(
@@ -118,7 +114,8 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('NOTIFICATION'),
-        onPressed: () => navigation.push(context, "setting-notification"),
+        onPressed: () =>
+            navigation.push(context, AppRoute.settingNotification.fullPath),
       ),
       SettingItem(
         Icon(
@@ -140,7 +137,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          navigation.push(context, 'tutorial', reset: true);
+          navigation.push(context, AppRoute.tutorial.fullPath, reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -62,7 +62,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await navigation.push(context, LockRegister.name);
+    await navigation.push(context, "lock-register");
 
     setState(() {
       readLockPinFromSF();
@@ -70,7 +70,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result = await navigation.push(context, LockAuth.name);
+    final result = await navigation.push(context, "lock-auth");
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -91,7 +91,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('ANNOUNCEMENT'),
-        onPressed: () => navigation.push(context, SettingAnnouncement.name),
+        onPressed: () => navigation.push(context, "setting-announcement"),
       ),
       SettingItem(
         Icon(
@@ -100,7 +100,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () => navigation.push(context, SettingOpinion.name),
+        onPressed: () => navigation.push(context, "setting-opinion"),
       ),
       SettingItem(
         Icon(
@@ -109,7 +109,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () => navigation.push(context, SettingFAQ.name),
+        onPressed: () => navigation.push(context, "setting-faq"),
       ),
       SettingItem(
         Icon(
@@ -118,7 +118,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('NOTIFICATION'),
-        onPressed: () => navigation.push(context, SettingNotification.name),
+        onPressed: () => navigation.push(context, "setting-notification"),
       ),
       SettingItem(
         Icon(
@@ -140,7 +140,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          navigation.push(context, Tutorial.name, reset: true);
+          navigation.push(context, 'tutorial', reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -152,7 +152,7 @@ class _SettingState extends State<Setting> {
     ];
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         context: context,
         iconColor: Theme.of(context).iconTheme.color,

--- a/lib/screens/setting_announcement.dart
+++ b/lib/screens/setting_announcement.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingAnnouncement extends StatelessWidget {
-  static const String name = '/setting_announcement';
+  static const String name = '/setting-announcement';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_announcement.dart
+++ b/lib/screens/setting_announcement.dart
@@ -48,7 +48,7 @@ class SettingAnnouncement extends StatelessWidget {
       ),
     ];
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_announcement.dart
+++ b/lib/screens/setting_announcement.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingAnnouncement extends StatelessWidget {
-  static const String name = '/setting-announcement';
+  const SettingAnnouncement({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -46,7 +46,7 @@ class _SettingCurrencyState extends State<SettingCurrency> {
         .toList();
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -14,9 +14,7 @@ class SettingCurrencyArguments {
 }
 
 class SettingCurrency extends StatefulWidget {
-  static const String name = '/setting_currency';
-
-  SettingCurrency({
+  const SettingCurrency({
     Key? key,
     this.title = '',
     this.selectedCurrency = '',

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -6,6 +6,13 @@ import '../widgets/header.dart' show renderHeaderBack;
 import '../widgets/setting_list_item.dart'
     show ListItem, TileItem, SettingTileItem;
 
+class SettingCurrencyArguments {
+  final String title;
+  final String? selectedCurrency;
+
+  SettingCurrencyArguments({this.title = '', this.selectedCurrency});
+}
+
 class SettingCurrency extends StatefulWidget {
   static const String name = '/setting_currency';
 

--- a/lib/screens/setting_excel.dart
+++ b/lib/screens/setting_excel.dart
@@ -6,7 +6,7 @@ import '../widgets/button.dart' show Button;
 import '../utils/asset.dart' as Asset;
 
 class SettingExcel extends StatelessWidget {
-  static const String name = '/setting-excel';
+  const SettingExcel({Key? key}) : super(key: key);
 
   void onExportExcel() {
     print('on send excel');

--- a/lib/screens/setting_excel.dart
+++ b/lib/screens/setting_excel.dart
@@ -16,7 +16,7 @@ class SettingExcel extends StatelessWidget {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_excel.dart
+++ b/lib/screens/setting_excel.dart
@@ -6,7 +6,7 @@ import '../widgets/button.dart' show Button;
 import '../utils/asset.dart' as Asset;
 
 class SettingExcel extends StatelessWidget {
-  static const String name = '/setting_excel';
+  static const String name = '/setting-excel';
 
   void onExportExcel() {
     print('on send excel');

--- a/lib/screens/setting_faq.dart
+++ b/lib/screens/setting_faq.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingFAQ extends StatelessWidget {
-  static const String name = '/setting_faq';
+  static const String name = '/setting-faq';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_faq.dart
+++ b/lib/screens/setting_faq.dart
@@ -84,7 +84,7 @@ class SettingFAQ extends StatelessWidget {
       ),
     ];
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_faq.dart
+++ b/lib/screens/setting_faq.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingFAQ extends StatelessWidget {
-  static const String name = '/setting-faq';
+  const SettingFAQ({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -5,7 +5,7 @@ import 'package:wecount/widgets/header.dart';
 import 'package:wecount/utils/localization.dart';
 
 class SettingNotification extends StatefulWidget {
-  static const String name = '/setting_notification';
+  static const String name = '/setting-notification';
 
   @override
   _SettingNotificationState createState() => _SettingNotificationState();

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -5,7 +5,7 @@ import 'package:wecount/widgets/header.dart';
 import 'package:wecount/utils/localization.dart';
 
 class SettingNotification extends StatefulWidget {
-  static const String name = '/setting-notification';
+  const SettingNotification({Key? key}) : super(key: key);
 
   @override
   _SettingNotificationState createState() => _SettingNotificationState();

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -29,7 +29,7 @@ class _SettingNotificationState extends State<SettingNotification> {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_opinion.dart
+++ b/lib/screens/setting_opinion.dart
@@ -16,7 +16,7 @@ class SettingOpinion extends StatelessWidget {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_opinion.dart
+++ b/lib/screens/setting_opinion.dart
@@ -6,7 +6,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
 
 class SettingOpinion extends StatelessWidget {
-  static const String name = '/setting-opinion';
+  const SettingOpinion({Key? key}) : super(key: key);
 
   void onSendOpinion() {
     print('on send opinion');

--- a/lib/screens/setting_opinion.dart
+++ b/lib/screens/setting_opinion.dart
@@ -6,7 +6,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
 
 class SettingOpinion extends StatelessWidget {
-  static const String name = '/setting_opinion';
+  static const String name = '/setting-opinion';
 
   void onSendOpinion() {
     print('on send opinion');

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:wecount/navigations/home_tab.dart';
-import 'package:wecount/screens/find_pw.dart';
-import 'package:wecount/screens/main_empty.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/widgets/edit_text.dart' show EditText;
@@ -15,9 +13,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
 class SignIn extends StatefulWidget {
-  static const String name = '/sign-in';
-
-  SignIn({Key? key}) : super(key: key);
+  const SignIn({Key? key}) : super(key: key);
 
   @override
   _SignInState createState() => _SignInState();
@@ -72,11 +68,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          navigation.push(context, 'main-empty', reset: true);
+          navigation.push(context, AppRoute.mainEmpty.fullPath, reset: true);
           return;
         }
 
-        navigation.push(context, 'home-tab', reset: true);
+        navigation.push(context, AppRoute.homeTab.fullPath, reset: true);
         return;
       }
     } catch (err) {
@@ -248,7 +244,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () => navigation.push(context, 'find-pw'),
+        onPressed: () => navigation.push(context, AppRoute.findPw.fullPath),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -274,10 +274,10 @@ class _SignInState extends State<SignIn> {
     }
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
         elevation: 0.0,
-        backgroundColor: Theme.of(context).backgroundColor,
+        backgroundColor: Theme.of(context).colorScheme.background,
         iconTheme: IconThemeData(
           color: Theme.of(context).textTheme.displayLarge!.color,
         ),

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -68,11 +68,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          navigation.push(context, AppRoute.mainEmpty.fullPath, reset: true);
+          navigation.push(context, AppRoute.mainEmpty.path, reset: true);
           return;
         }
 
-        navigation.push(context, AppRoute.homeTab.fullPath, reset: true);
+        navigation.push(context, AppRoute.homeTab.path, reset: true);
         return;
       }
     } catch (err) {
@@ -244,7 +244,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () => navigation.push(context, AppRoute.findPw.fullPath),
+        onPressed: () => navigation.push(context, AppRoute.findPw.path),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -72,11 +72,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          navigation.push(context, MainEmpty.name, reset: true);
+          navigation.push(context, 'main-empty', reset: true);
           return;
         }
 
-        navigation.push(context, HomeTab.name, reset: true);
+        navigation.push(context, 'home-tab', reset: true);
         return;
       }
     } catch (err) {
@@ -248,7 +248,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () => navigation.push(context, FindPw.name),
+        onPressed: () => navigation.push(context, 'find-pw'),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -4,10 +4,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wecount/navigations/home_tab.dart';
 import 'package:wecount/screens/find_pw.dart';
 import 'package:wecount/screens/main_empty.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/widgets/edit_text.dart' show EditText;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/validator.dart' show Validator;
 
@@ -15,7 +15,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
 class SignIn extends StatefulWidget {
-  static const String name = '/sign_in';
+  static const String name = '/sign-in';
 
   SignIn({Key? key}) : super(key: key);
 
@@ -72,13 +72,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          General.instance
-              .navigateScreenNamed(context, MainEmpty.name, reset: true);
+          navigation.push(context, MainEmpty.name, reset: true);
           return;
         }
 
-        General.instance
-            .navigateScreenNamed(context, HomeTab.name, reset: true);
+        navigation.push(context, HomeTab.name, reset: true);
         return;
       }
     } catch (err) {
@@ -105,7 +103,7 @@ class _SignInState extends State<SignIn> {
     }
 
     if (auth.user != null && !auth.user!.emailVerified) {
-      General.instance.showSingleDialog(
+      navigation.showSingleDialog(
         context,
         title: Text(_localization!.trans('ERROR')!),
         content: Column(
@@ -250,8 +248,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () =>
-            General.instance.navigateScreenNamed(context, FindPw.name),
+        onPressed: () => navigation.push(context, FindPw.name),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -13,9 +13,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
 class SignUp extends StatefulWidget {
-  static const String name = '/sign-up';
-
-  SignUp({Key? key}) : super(key: key);
+  const SignUp({Key? key}) : super(key: key);
 
   @override
   _SignUpState createState() => _SignUpState();

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:wecount/utils/navigation.dart';
 
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/widgets/edit_text.dart' show EditText;
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/localization.dart' show Localization;
@@ -13,7 +13,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
 class SignUp extends StatefulWidget {
-  static const String name = '/sign_up';
+  static const String name = '/sign-up';
 
   SignUp({Key? key}) : super(key: key);
 
@@ -100,7 +100,7 @@ class _SignUpState extends State<SignUp> {
 
         user.updateDisplayName(_displayName);
 
-        return General.instance.showSingleDialog(
+        return navigation.showSingleDialog(
           context,
           title: Text(
             _localization!.trans('SIGN_UP_SUCCESS_TITLE')!,
@@ -121,7 +121,7 @@ class _SignUpState extends State<SignUp> {
 
       throw Error();
     } catch (err) {
-      General.instance.showSingleDialog(
+      navigation.showSingleDialog(
         context,
         title: Text(
           _localization!.trans('SIGN_UP_ERROR_TITLE')!,

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -19,7 +19,7 @@ class _SplashState extends State<Splash> {
   Timer? _timer;
 
   Future<void> navigateRoute() async {
-    String initialRoute = AppRoute.tutorial.fullPath;
+    String initialRoute = AppRoute.tutorial.path;
 
     _navigationTimer = Timer(Duration(milliseconds: 1500), () {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:wecount/screens/tutorial.dart';
 
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
+import 'package:wecount/utils/navigation.dart';
 
 class Splash extends StatefulWidget {
   static const String name = '/splash';
@@ -26,7 +26,7 @@ class _SplashState extends State<Splash> {
     _navigationTimer = Timer(Duration(milliseconds: 1500), () {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
           overlays: SystemUiOverlay.values);
-      General.instance.navigateScreenNamed(context, initialRoute, reset: true);
+      navigation.push(context, initialRoute, reset: true);
     });
   }
 

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -1,15 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:wecount/screens/tutorial.dart';
 
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 class Splash extends StatefulWidget {
-  static const String name = '/splash';
-
-  Splash({Key? key}) : super(key: key);
+  const Splash({Key? key}) : super(key: key);
 
   @override
   _SplashState createState() => _SplashState();
@@ -21,7 +19,7 @@ class _SplashState extends State<Splash> {
   Timer? _timer;
 
   Future<void> navigateRoute() async {
-    String initialRoute = Tutorial.name;
+    String initialRoute = AppRoute.tutorial.fullPath;
 
     _navigationTimer = Timer(Duration(milliseconds: 1500), () {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,

--- a/lib/screens/terms.dart
+++ b/lib/screens/terms.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 
 class Terms extends StatefulWidget {
-  static const String name = '/terms';
-
-  Terms({Key? key}) : super(key: key);
+  const Terms({Key? key}) : super(key: key);
 
   @override
   _TermsState createState() => _TermsState();

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:wecount/screens/intro.dart';
 
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
+import 'package:wecount/utils/routes.dart';
 
 class Tutorial extends StatefulWidget {
-  static const String name = '/tutorial';
+  const Tutorial({Key? key}) : super(key: key);
 
   @override
   _TutorialState createState() => _TutorialState();
@@ -19,7 +19,8 @@ class _TutorialState extends State<Tutorial> {
   );
   void onNextPressed() {
     if (_currentPage == pageCnt) {
-      Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
+      Navigator.pushNamedAndRemoveUntil(
+          context, AppRoute.intro.fullPath, (_) => false);
       return;
     }
     _pageController.nextPage(

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -19,7 +19,7 @@ class _TutorialState extends State<Tutorial> {
   );
   void onNextPressed() {
     if (_currentPage == pageCnt) {
-      Navigator.pushNamedAndRemoveUntil(context, Intro.name, (_) => false);
+      Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
       return;
     }
     _pageController.nextPage(

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -8,6 +8,7 @@ import 'package:wecount/models/ledger.dart';
 import 'package:wecount/models/user.dart' as UserM;
 import 'package:wecount/services/storage.dart';
 import 'package:wecount/utils/db_helper.dart';
+import 'package:wecount/utils/logger.dart';
 
 class DatabaseService {
   final FirebaseFirestore _db = FirebaseFirestore.instance;

--- a/lib/utils/db_helper.dart
+++ b/lib/utils/db_helper.dart
@@ -164,9 +164,11 @@ class DBHelper {
     return db.delete('categories', where: "iconId = ?", whereArgs: [iconId]);
   }
 
-  bool isExistFiled(DocumentSnapshot doc, String filedName) {
-    Map data = doc.data() as Map;
-
-    return data[filedName] != null;
+  bool isExistFiled(doc, String filedName) {
+    if (doc.data() != null) {
+      Map data = doc.data();
+      return data[filedName] != null;
+    }
+    return false;
   }
 }

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -23,13 +23,13 @@ class _Navigation {
     if (reset) {
       return Navigator.pushNamedAndRemoveUntil(
         context,
-        '$routeName',
-        ModalRoute.withName('$routeName'),
+        '/$routeName',
+        ModalRoute.withName('/$routeName'),
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
   }
 
   Future navigate(
@@ -40,14 +40,14 @@ class _Navigation {
   }) {
     if (reset) {
       return Navigator.of(context).pushNamedAndRemoveUntil(
-        '$routeName',
+        '/$routeName',
         (route) =>
             route.isCurrent && route.settings.name == routeName ? false : true,
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
   }
 
   void pop<T extends String>(
@@ -64,7 +64,7 @@ class _Navigation {
     return Navigator.popUntil(
       context,
       (route) {
-        return route.settings.name == '$routeName';
+        return route.settings.name == '/$routeName';
       },
     );
   }

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -23,13 +23,13 @@ class _Navigation {
     if (reset) {
       return Navigator.pushNamedAndRemoveUntil(
         context,
-        '/$routeName',
-        ModalRoute.withName('/$routeName'),
+        '$routeName',
+        ModalRoute.withName('$routeName'),
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
   }
 
   Future navigate(
@@ -40,14 +40,14 @@ class _Navigation {
   }) {
     if (reset) {
       return Navigator.of(context).pushNamedAndRemoveUntil(
-        '/$routeName',
+        '$routeName',
         (route) =>
             route.isCurrent && route.settings.name == routeName ? false : true,
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
   }
 
   void pop<T extends String>(
@@ -64,7 +64,7 @@ class _Navigation {
     return Navigator.popUntil(
       context,
       (route) {
-        return route.settings.name == '/$routeName';
+        return route.settings.name == '$routeName';
       },
     );
   }

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -128,14 +128,21 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
   }
 
   if (settings.name == LedgerEdit.name) {
-    final LedgerEditArguments args = settings.arguments as LedgerEditArguments;
+    if (settings.arguments == null) {
+      return MaterialPageRoute(builder: (context) {
+        return LedgerEdit();
+      });
+    } else {
+      final LedgerEditArguments args =
+          settings.arguments as LedgerEditArguments;
 
-    return MaterialPageRoute(builder: (context) {
-      return LedgerEdit(
-        ledger: args.ledger,
-        mode: args.mode,
-      );
-    });
+      return MaterialPageRoute(builder: (context) {
+        return LedgerEdit(
+          ledger: args.ledger,
+          mode: args.mode,
+        );
+      });
+    }
   }
 
   throw 'Route not found: ${settings.name}';

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/navigations/home_tab.dart';
 import 'package:wecount/screens/find_pw.dart';
@@ -7,10 +8,14 @@ import 'package:wecount/screens/ledger_item_edit.dart';
 import 'package:wecount/screens/ledger_view.dart';
 import 'package:wecount/screens/ledgers.dart';
 import 'package:wecount/screens/line_graph.dart';
+import 'package:wecount/screens/location_view.dart';
 import 'package:wecount/screens/lock_auth.dart';
 import 'package:wecount/screens/lock_register.dart';
 import 'package:wecount/screens/main_empty.dart';
+import 'package:wecount/screens/members.dart';
+import 'package:wecount/screens/photo_detail.dart';
 import 'package:wecount/screens/profile_my.dart';
+import 'package:wecount/screens/profile_peer.dart';
 import 'package:wecount/screens/setting.dart';
 import 'package:wecount/screens/setting_announcement.dart';
 import 'package:wecount/screens/setting_currency.dart';
@@ -35,8 +40,6 @@ final routes = {
   MainEmpty.name: (context) => MainEmpty(),
   HomeTab.name: (context) => HomeTab(),
   Ledgers.name: (context) => Ledgers(),
-  LedgerEdit.name: (context) => LedgerEdit(),
-  LedgerView.name: (context) => LedgerView(),
   Terms.name: (context) => Terms(),
   ProfileMy.name: (context) => ProfileMy(),
   Setting.name: (context) => Setting(),
@@ -45,9 +48,95 @@ final routes = {
   SettingFAQ.name: (context) => SettingFAQ(),
   SettingNotification.name: (context) => SettingNotification(),
   LedgerItemEdit.name: (context) => LedgerItemEdit(),
-  SettingCurrency.name: (context) => SettingCurrency(),
   SettingExcel.name: (context) => SettingExcel(),
   LockRegister.name: (context) => LockRegister(),
   LockAuth.name: (context) => LockAuth(),
-  LineGraph.name: (context) => LineGraph(),
+  LocationView.name: (context) => LocationView()
 };
+
+MaterialPageRoute onGenerateRoute(RouteSettings settings) {
+  // If you push the PassArguments route
+  if (settings.name == PhotoDetail.name) {
+    final PhotoDetailArguments args =
+        settings.arguments as PhotoDetailArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return PhotoDetail(
+        canShare: args.canShare,
+        onPressDelete: args.onPressDelete,
+        onPressDownload: args.onPressDownload,
+        onPressShare: args.onPressShare,
+        photo: args.photo,
+        photoUrl: args.photoUrl,
+      );
+    });
+  }
+
+  if (settings.name == LineGraph.name) {
+    final LineGraphArguments args = settings.arguments as LineGraphArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return LineGraph(
+        title: args.title,
+        year: args.year,
+        price: args.price!,
+      );
+    });
+  }
+
+  if (settings.name == Members.name) {
+    final MembersArguments args = settings.arguments as MembersArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return Members(
+        ledger: args.ledger,
+      );
+    });
+  }
+
+  if (settings.name == SettingCurrency.name) {
+    final SettingCurrencyArguments args =
+        settings.arguments as SettingCurrencyArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return SettingCurrency(
+        selectedCurrency: args.selectedCurrency,
+        title: args.title,
+      );
+    });
+  }
+
+  if (settings.name == ProfilePeer.name) {
+    final ProfilePeerArguments args =
+        settings.arguments as ProfilePeerArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return ProfilePeer(
+        user: args.user,
+      );
+    });
+  }
+
+  if (settings.name == LedgerView.name) {
+    final LedgerViewArguments args = settings.arguments as LedgerViewArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return LedgerView(
+        ledger: args.ledger,
+      );
+    });
+  }
+
+  if (settings.name == LedgerEdit.name) {
+    final LedgerEditArguments args = settings.arguments as LedgerEditArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return LedgerEdit(
+        ledger: args.ledger,
+        mode: args.mode,
+      );
+    });
+  }
+
+  throw 'Route not found: ${settings.name}';
+}

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/navigations/home_tab.dart';
@@ -29,34 +30,96 @@ import 'package:wecount/screens/splash.dart';
 import 'package:wecount/screens/terms.dart';
 import 'package:wecount/screens/tutorial.dart';
 
+enum AppRoute {
+  authSwitch,
+  splash,
+  tutorial,
+  intro,
+  signIn,
+  signUp,
+  findPw,
+  mainEmpty,
+  homeTab,
+  ledgers,
+  terms,
+  profileMy,
+  setting,
+  settingAnnouncement,
+  settingOpinion,
+  settingFAQ,
+  settingNotification,
+  ledgerItemEdit,
+  settingExcel,
+  lockRegister,
+  lockAuth,
+  locationView,
+  photoDetail,
+  lineGraph,
+  members,
+  settingCurrency,
+  profilePeer,
+  ledgerView,
+  ledgerEdit,
+}
+
+extension RouteName on AppRoute {
+  String get name => describeEnum(this);
+
+  bool get isRoot => this == AppRoute.authSwitch;
+
+  /// Convert to `lower-snake-case` format.
+  String get path {
+    if (isRoot) return '';
+
+    RegExp exp = RegExp(r'(?<=[a-z])[A-Z]');
+    String result = name
+        .replaceAllMapped(exp, (Match m) => ('-${m.group(0)}'))
+        .toLowerCase();
+    return result;
+  }
+
+  /// Convert to `lower-snake-case` format with `/`.
+  String get fullPath {
+    if (isRoot) return '/';
+
+    RegExp exp = RegExp(r'(?<=[a-z])[A-Z]');
+    String result = name
+        .replaceAllMapped(exp, (Match m) => ('-${m.group(0)}'))
+        .toLowerCase();
+    return '/$result';
+  }
+}
+
 final routes = {
-  AuthSwitch.name: (context) => AuthSwitch(),
-  Splash.name: (context) => Splash(),
-  Tutorial.name: (context) => Tutorial(),
-  Intro.name: (context) => Intro(),
-  SignIn.name: (context) => SignIn(),
-  SignUp.name: (context) => SignUp(),
-  FindPw.name: (context) => FindPw(),
-  MainEmpty.name: (context) => MainEmpty(),
-  HomeTab.name: (context) => HomeTab(),
-  Ledgers.name: (context) => Ledgers(),
-  Terms.name: (context) => Terms(),
-  ProfileMy.name: (context) => ProfileMy(),
-  Setting.name: (context) => Setting(),
-  SettingAnnouncement.name: (context) => SettingAnnouncement(),
-  SettingOpinion.name: (context) => SettingOpinion(),
-  SettingFAQ.name: (context) => SettingFAQ(),
-  SettingNotification.name: (context) => SettingNotification(),
-  LedgerItemEdit.name: (context) => LedgerItemEdit(),
-  SettingExcel.name: (context) => SettingExcel(),
-  LockRegister.name: (context) => LockRegister(),
-  LockAuth.name: (context) => LockAuth(),
-  LocationView.name: (context) => LocationView()
+  AppRoute.authSwitch.fullPath: (context) => const AuthSwitch(),
+  AppRoute.splash.fullPath: (context) => const Splash(),
+  AppRoute.tutorial.fullPath: (context) => const Tutorial(),
+  AppRoute.intro.fullPath: (context) => const Intro(),
+  AppRoute.signIn.fullPath: (context) => const SignIn(),
+  AppRoute.signUp.fullPath: (context) => const SignIn(),
+  AppRoute.findPw.fullPath: (context) => const FindPw(),
+  AppRoute.mainEmpty.fullPath: (context) => const MainEmpty(),
+  AppRoute.homeTab.fullPath: (context) => const HomeTab(),
+  AppRoute.ledgers.fullPath: (context) => const Ledgers(),
+  AppRoute.terms.fullPath: (context) => const Terms(),
+  AppRoute.profileMy.fullPath: (context) => const ProfileMy(),
+  AppRoute.setting.fullPath: (context) => const Setting(),
+  AppRoute.settingAnnouncement.fullPath: (context) =>
+      const SettingAnnouncement(),
+  AppRoute.settingOpinion.fullPath: (context) => const SettingOpinion(),
+  AppRoute.settingFAQ.fullPath: (context) => const SettingFAQ(),
+  AppRoute.settingNotification.fullPath: (context) =>
+      const SettingNotification(),
+  AppRoute.ledgerItemEdit.fullPath: (context) => const LedgerItemEdit(),
+  AppRoute.settingExcel.fullPath: (context) => const SettingExcel(),
+  AppRoute.lockRegister.fullPath: (context) => const LockRegister(),
+  AppRoute.lockAuth.fullPath: (context) => const LockAuth(),
+  AppRoute.locationView.fullPath: (context) => const LocationView()
 };
 
 MaterialPageRoute onGenerateRoute(RouteSettings settings) {
   // If you push the PassArguments route
-  if (settings.name == PhotoDetail.name) {
+  if (settings.name == AppRoute.photoDetail.fullPath) {
     final PhotoDetailArguments args =
         settings.arguments as PhotoDetailArguments;
 
@@ -72,7 +135,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == LineGraph.name) {
+  if (settings.name == AppRoute.lineGraph.fullPath) {
     final LineGraphArguments args = settings.arguments as LineGraphArguments;
 
     return MaterialPageRoute(builder: (context) {
@@ -84,7 +147,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == Members.name) {
+  if (settings.name == AppRoute.members.fullPath) {
     final MembersArguments args = settings.arguments as MembersArguments;
 
     return MaterialPageRoute(builder: (context) {
@@ -94,7 +157,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == SettingCurrency.name) {
+  if (settings.name == AppRoute.settingCurrency.fullPath) {
     final SettingCurrencyArguments args =
         settings.arguments as SettingCurrencyArguments;
 
@@ -106,7 +169,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == ProfilePeer.name) {
+  if (settings.name == AppRoute.profilePeer.fullPath) {
     final ProfilePeerArguments args =
         settings.arguments as ProfilePeerArguments;
 
@@ -117,7 +180,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == LedgerView.name) {
+  if (settings.name == AppRoute.ledgerView.fullPath) {
     final LedgerViewArguments args = settings.arguments as LedgerViewArguments;
 
     return MaterialPageRoute(builder: (context) {
@@ -127,7 +190,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == LedgerEdit.name) {
+  if (settings.name == AppRoute.ledgerEdit.fullPath) {
     if (settings.arguments == null) {
       return MaterialPageRoute(builder: (context) {
         return LedgerEdit();

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -96,7 +96,7 @@ final routes = {
   AppRoute.tutorial.fullPath: (context) => const Tutorial(),
   AppRoute.intro.fullPath: (context) => const Intro(),
   AppRoute.signIn.fullPath: (context) => const SignIn(),
-  AppRoute.signUp.fullPath: (context) => const SignIn(),
+  AppRoute.signUp.fullPath: (context) => const SignUp(),
   AppRoute.findPw.fullPath: (context) => const FindPw(),
   AppRoute.mainEmpty.fullPath: (context) => const MainEmpty(),
   AppRoute.homeTab.fullPath: (context) => const HomeTab(),
@@ -114,7 +114,8 @@ final routes = {
   AppRoute.settingExcel.fullPath: (context) => const SettingExcel(),
   AppRoute.lockRegister.fullPath: (context) => const LockRegister(),
   AppRoute.lockAuth.fullPath: (context) => const LockAuth(),
-  AppRoute.locationView.fullPath: (context) => const LocationView()
+  AppRoute.locationView.fullPath: (context) => const LocationView(),
+  AppRoute.ledgerEdit.fullPath: (context) => const LedgerEdit()
 };
 
 MaterialPageRoute onGenerateRoute(RouteSettings settings) {
@@ -191,21 +192,14 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
   }
 
   if (settings.name == AppRoute.ledgerEdit.fullPath) {
-    if (settings.arguments == null) {
-      return MaterialPageRoute(builder: (context) {
-        return LedgerEdit();
-      });
-    } else {
-      final LedgerEditArguments args =
-          settings.arguments as LedgerEditArguments;
+    final LedgerEditArguments args = settings.arguments as LedgerEditArguments;
 
-      return MaterialPageRoute(builder: (context) {
-        return LedgerEdit(
-          ledger: args.ledger,
-          mode: args.mode,
-        );
-      });
-    }
+    return MaterialPageRoute(builder: (context) {
+      return LedgerEdit(
+        ledger: args.ledger,
+        mode: args.mode,
+      );
+    });
   }
 
   throw 'Route not found: ${settings.name}';

--- a/lib/widgets/category_item.dart
+++ b/lib/widgets/category_item.dart
@@ -73,7 +73,7 @@ class _CategoryItemState extends State<CategoryItem> {
                                 Theme.of(context).textTheme.displayLarge!.color,
                             child: Icon(
                               Icons.close,
-                              color: Theme.of(context).backgroundColor,
+                              color: Theme.of(context).colorScheme.background,
                               size: 18,
                             ),
                           ),

--- a/lib/widgets/category_list.dart
+++ b/lib/widgets/category_list.dart
@@ -1,7 +1,7 @@
 import 'package:wecount/models/category.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/category_item.dart';
 import 'package:wecount/utils/db_helper.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
@@ -34,7 +34,7 @@ class _CategoryListState extends State<CategoryList> {
                 Navigator.pop(context, category);
               },
               onDeletePressed: () {
-                General.instance.showConfirmDialog(context,
+                navigation.showConfirmDialog(context,
                     title: Text(_localization!.trans('DELETE')!),
                     content: Text(_localization.trans('DELETE_ASK')!),
                     okPressed: () async {

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -76,7 +76,7 @@ Future<PhotoOption?> _asyncPhotoSelect(BuildContext context) async {
               ),
             ),
           ],
-          backgroundColor: Theme.of(context).backgroundColor,
+          backgroundColor: Theme.of(context).colorScheme.background,
         );
       });
 }

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -7,8 +7,8 @@ import 'package:wecount/screens/photo_detail.dart';
 import 'package:wecount/models/photo.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart' show Localization;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:image_picker/image_picker.dart';
+import 'package:wecount/utils/navigation.dart';
 
 enum PhotoOption { Camera, Gallery }
 
@@ -173,12 +173,12 @@ class _GalleryState extends State<Gallery> {
                         XFile? imgFile;
                         switch (photoOption) {
                           case PhotoOption.Camera:
-                            imgFile = await General.instance
-                                .chooseImage(context: context, type: 'camera');
+                            imgFile = await navigation.chooseImage(
+                                context: context, type: 'camera');
                             break;
                           case PhotoOption.Gallery:
-                            imgFile = await General.instance
-                                .chooseImage(context: context, type: 'gallery');
+                            imgFile = await navigation.chooseImage(
+                                context: context, type: 'gallery');
                             break;
                           default:
                             break;
@@ -231,21 +231,19 @@ class _GalleryState extends State<Gallery> {
                             color: Colors.transparent,
                             child: InkWell(
                               splashColor: Asset.Colors.paleGray,
-                              onTap: () => General.instance.navigateScreen(
+                              onTap: () => navigation.navigate(
                                 context,
-                                MaterialPageRoute(
-                                  builder: (BuildContext context) =>
-                                      PhotoDetail(
-                                    photo: photo,
-                                    onPressDelete: () {
-                                      int index = _pictures.indexWhere(
-                                          (Photo compare) =>
-                                              compare.file == photo.file);
-                                      _pictures.removeAt(index);
-                                      widget.ledgerItem.picture = _pictures;
-                                      Navigator.of(context).pop();
-                                    },
-                                  ),
+                                'photo-detail',
+                                arguments: PhotoDetailArguments(
+                                  photo: photo,
+                                  onPressDelete: () {
+                                    int index = _pictures.indexWhere(
+                                        (Photo compare) =>
+                                            compare.file == photo.file);
+                                    _pictures.removeAt(index);
+                                    widget.ledgerItem.picture = _pictures;
+                                    Navigator.of(context).pop();
+                                  },
                                 ),
                               ),
                             ),

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -9,6 +9,7 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:image_picker/image_picker.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 enum PhotoOption { Camera, Gallery }
 
@@ -233,7 +234,7 @@ class _GalleryState extends State<Gallery> {
                               splashColor: Asset.Colors.paleGray,
                               onTap: () => navigation.navigate(
                                 context,
-                                'photo-detail',
+                                AppRoute.photoDetail.fullPath,
                                 arguments: PhotoDetailArguments(
                                   photo: photo,
                                   onPressDelete: () {

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -234,7 +234,7 @@ class _GalleryState extends State<Gallery> {
                               splashColor: Asset.Colors.paleGray,
                               onTap: () => navigation.navigate(
                                 context,
-                                AppRoute.photoDetail.fullPath,
+                                AppRoute.photoDetail.path,
                                 arguments: PhotoDetailArguments(
                                   photo: photo,
                                   onPressDelete: () {

--- a/lib/widgets/home_header_search.dart
+++ b/lib/widgets/home_header_search.dart
@@ -69,51 +69,44 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
           fontSize: 16.0),
       height: 40.0,
     );
-    return AppBar(
-      elevation: 0.0,
-      titleSpacing: 0.0,
-      backgroundColor: widget.color,
-      actions: widget.actions,
-      title: Container(
-        margin: widget.margin,
-        child: Stack(
-          children: <Widget>[
-            textInput,
-            Positioned(
-              child: Container(
-                child: Icon(
-                  Icons.search,
-                  color: Colors.white,
-                ),
-                width: 16.0,
-                height: 16.0,
-              ),
-              left: 12.0,
-              top: 12.0,
-            ),
-            _showClose == true
-                ? Positioned(
-                    child: Container(
-                      child: RawMaterialButton(
-                        onPressed: () {
-                          setState(() {
-                            widget.textEditingController!.clear();
-                            _showClose = false;
-                          });
-                        },
-                        shape: CircleBorder(),
-                        child: Icon(Icons.close, color: Colors.white),
-                        padding: EdgeInsets.all(0.0),
-                      ),
-                      width: 40.0,
-                      height: 40.0,
-                    ),
-                    right: 8.0,
-                  )
-                : Container(height: 40.0),
-          ],
+    return Stack(children: [
+      Container(margin: EdgeInsets.only(left: 20, right: 50), child: textInput),
+      Positioned(
+        child: Container(
+          child: Icon(
+            Icons.search,
+            color: Colors.white,
+          ),
+          width: 16.0,
+          height: 16.0,
         ),
+        left: 32.0,
+        top: 12.0,
       ),
-    );
+      _showClose == true
+          ? Positioned(
+              child: Container(
+                child: RawMaterialButton(
+                  onPressed: () {
+                    setState(() {
+                      widget.textEditingController!.clear();
+                      _showClose = false;
+                    });
+                  },
+                  shape: CircleBorder(),
+                  child: Icon(Icons.close, color: Colors.white),
+                  padding: EdgeInsets.all(0.0),
+                ),
+                width: 50.0,
+              ),
+              right: 0.0,
+            )
+          : Positioned(
+              child: Row(
+                children: widget.actions!,
+              ),
+              right: 0.0,
+            ),
+    ]);
   }
 }

--- a/lib/widgets/home_header_search.dart
+++ b/lib/widgets/home_header_search.dart
@@ -4,30 +4,32 @@ import 'package:wecount/widgets/edit_text_search.dart' show EditTextSearch;
 import 'package:wecount/utils/localization.dart' show Localization;
 
 class HomeHeaderSearch extends StatefulWidget {
-  HomeHeaderSearch({
-    Key? key,
-    this.margin,
-    this.showSearchInput = false,
-    this.textEditingController,
-    this.actions,
-    this.onClose,
-    this.onSubmit,
-    this.color,
-  }) : super(key: key);
+  HomeHeaderSearch(
+      {Key? key,
+      this.margin,
+      this.showSearchInput = false,
+      this.textEditingController,
+      this.onClose,
+      this.onSubmit,
+      this.color,
+      required this.onPressAdd,
+      required this.onPressDelete})
+      : super(key: key);
   final EdgeInsets? margin;
   final bool showSearchInput;
   final TextEditingController? textEditingController;
-  final List<Widget>? actions;
   final Function? onClose;
   final Function? onSubmit;
   final Color? color;
+  final Function onPressAdd;
+  final Function onPressDelete;
 
   @override
   _HomeHeaderSearchState createState() => _HomeHeaderSearchState();
 }
 
 class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
-  bool _showClose = false;
+  var searchText = "";
 
   @override
   Widget build(BuildContext context) {
@@ -36,15 +38,9 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
       controller: widget.textEditingController,
       textInputAction: TextInputAction.search,
       onChanged: (text) {
-        if (text == '') {
-          setState(() {
-            _showClose = false;
-          });
-        } else {
-          setState(() {
-            _showClose = true;
-          });
-        }
+        setState(() {
+          searchText = text;
+        });
       },
       onSubmit: widget.onSubmit,
       background: Colors.transparent,
@@ -83,15 +79,12 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
         left: 32.0,
         top: 12.0,
       ),
-      _showClose == true
+      searchText != ""
           ? Positioned(
               child: Container(
                 child: RawMaterialButton(
                   onPressed: () {
-                    setState(() {
-                      widget.textEditingController!.clear();
-                      _showClose = false;
-                    });
+                    widget.onPressDelete();
                   },
                   shape: CircleBorder(),
                   child: Icon(Icons.close, color: Colors.white),
@@ -102,8 +95,19 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
               right: 0.0,
             )
           : Positioned(
-              child: Row(
-                children: widget.actions!,
+              child: Container(
+                width: 50.0,
+                child: RawMaterialButton(
+                  padding: EdgeInsets.all(0.0),
+                  shape: CircleBorder(),
+                  onPressed: () {
+                    widget.onPressAdd();
+                  },
+                  child: Icon(
+                    Icons.add,
+                    color: Colors.white,
+                  ),
+                ),
               ),
               right: 0.0,
             ),

--- a/lib/widgets/home_list_item.dart
+++ b/lib/widgets/home_list_item.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/utils/logger.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 class HomeListItem extends StatelessWidget {
   final LedgerItem? ledgerItem;
@@ -62,7 +63,7 @@ class HomeListItem extends StatelessWidget {
         _priceFormatted.toString().replaceAll('-', '');
 
     return TextButton(
-      onPressed: () => navigation.push(context, 'line-graph',
+      onPressed: () => navigation.push(context, AppRoute.lineGraph.fullPath,
           arguments: LineGraphArguments(_label, '2022', ledgerItem!.price)),
       child: Container(
         height: 60,

--- a/lib/widgets/home_list_item.dart
+++ b/lib/widgets/home_list_item.dart
@@ -4,7 +4,8 @@ import 'package:wecount/screens/line_graph.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:intl/intl.dart';
 import 'package:wecount/models/user.dart';
-import 'package:wecount/utils/general.dart' show General;
+import 'package:wecount/utils/logger.dart';
+import 'package:wecount/utils/navigation.dart';
 
 class HomeListItem extends StatelessWidget {
   final LedgerItem? ledgerItem;
@@ -61,8 +62,8 @@ class HomeListItem extends StatelessWidget {
         _priceFormatted.toString().replaceAll('-', '');
 
     return TextButton(
-      onPressed: () =>
-          General.instance.navigateScreenNamed(context, LineGraph.name),
+      onPressed: () => navigation.push(context, 'line-graph',
+          arguments: LineGraphArguments(_label, '2022', ledgerItem!.price)),
       child: Container(
         height: 60,
         child: Row(

--- a/lib/widgets/home_list_item.dart
+++ b/lib/widgets/home_list_item.dart
@@ -63,7 +63,7 @@ class HomeListItem extends StatelessWidget {
         _priceFormatted.toString().replaceAll('-', '');
 
     return TextButton(
-      onPressed: () => navigation.push(context, AppRoute.lineGraph.fullPath,
+      onPressed: () => navigation.push(context, AppRoute.lineGraph.path,
           arguments: LineGraphArguments(_label, '2022', ledgerItem!.price)),
       child: Container(
         height: 60,

--- a/lib/widgets/line_graph_chart.dart
+++ b/lib/widgets/line_graph_chart.dart
@@ -168,7 +168,7 @@ class _LineGraphChartState extends State<LineGraphChart> {
           spots: _spots,
           isCurved: false,
           // colors: gradientColors,
-          color: gradientColors.single,
+          color: gradientColors.first,
           barWidth: 5,
           isStrokeCapRound: true,
           dotData: FlDotData(
@@ -178,7 +178,7 @@ class _LineGraphChartState extends State<LineGraphChart> {
             show: true,
             // colors:
             //     gradientColors.map((color) => color.withOpacity(0.3)).toList(),
-            color: gradientColors.single,
+            color: gradientColors.first,
           ),
         ),
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,10 @@ description: The social ledger app.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.17.6 <4.0.0"
+
+dependency_overrides:
+  firebase_core_platform_interface: 4.5.1
   
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,8 @@ dependencies:
   flutter_native_image: ^0.0.6+1
   logger: ^1.1.0
   flutter_spinkit: ^5.1.0
+  flat_list: ^0.1.3
+  flutter_hooks: ^0.18.5+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,8 +58,6 @@ dependencies:
   flutter_native_image: ^0.0.6+1
   logger: ^1.1.0
   flutter_spinkit: ^5.1.0
-  flat_list: ^0.1.3
-  flutter_hooks: ^0.18.5+1
 
 dev_dependencies:
   flutter_test:

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -25,6 +25,7 @@ import 'package:wecount/screens/sign_up.dart' show SignUp;
 import 'package:wecount/screens/find_pw.dart' show FindPw;
 import 'package:wecount/screens/terms.dart' show Terms;
 import 'package:provider/provider.dart';
+import 'package:wecount/utils/routes.dart';
 
 class MockNavigatorObserver extends Mock implements NavigatorObserver {}
 
@@ -44,24 +45,25 @@ class TestUtils {
         home: child,
         navigatorObservers: <NavigatorObserver>[observer],
         routes: {
-          Splash.name: (BuildContext context) => Splash(),
-          Tutorial.name: (BuildContext context) => Tutorial(),
-          Intro.name: (BuildContext context) => Intro(),
-          SignIn.name: (BuildContext context) => SignIn(),
-          SignUp.name: (BuildContext context) => SignUp(),
-          FindPw.name: (BuildContext context) => FindPw(),
-          MainEmpty.name: (BuildContext context) => MainEmpty(),
-          HomeTab.name: (BuildContext context) => HomeTab(),
-          Ledgers.name: (BuildContext context) => Ledgers(),
-          LedgerEdit.name: (BuildContext context) => LedgerEdit(),
-          Terms.name: (BuildContext context) => Terms(),
-          ProfileMy.name: (BuildContext context) => ProfileMy(),
-          Setting.name: (BuildContext context) => Setting(),
-          SettingAnnouncement.name: (BuildContext context) =>
+          AppRoute.splash.fullPath: (BuildContext context) => Splash(),
+          AppRoute.tutorial.fullPath: (BuildContext context) => Tutorial(),
+          AppRoute.intro.fullPath: (BuildContext context) => Intro(),
+          AppRoute.signIn.fullPath: (BuildContext context) => SignIn(),
+          AppRoute.signUp.fullPath: (BuildContext context) => SignUp(),
+          AppRoute.findPw.fullPath: (BuildContext context) => FindPw(),
+          AppRoute.mainEmpty.fullPath: (BuildContext context) => MainEmpty(),
+          AppRoute.homeTab.fullPath: (BuildContext context) => HomeTab(),
+          AppRoute.ledgers.fullPath: (BuildContext context) => Ledgers(),
+          AppRoute.ledgerEdit.fullPath: (BuildContext context) => LedgerEdit(),
+          AppRoute.terms.fullPath: (BuildContext context) => Terms(),
+          AppRoute.profileMy.fullPath: (BuildContext context) => ProfileMy(),
+          AppRoute.setting.fullPath: (BuildContext context) => Setting(),
+          AppRoute.settingAnnouncement.fullPath: (BuildContext context) =>
               SettingAnnouncement(),
-          SettingOpinion.name: (BuildContext context) => SettingOpinion(),
-          SettingFAQ.name: (BuildContext context) => SettingFAQ(),
-          SettingNotification.name: (BuildContext context) =>
+          AppRoute.settingOpinion.fullPath: (BuildContext context) =>
+              SettingOpinion(),
+          AppRoute.settingFAQ.fullPath: (BuildContext context) => SettingFAQ(),
+          AppRoute.settingNotification.fullPath: (BuildContext context) =>
               SettingNotification(),
         },
       ),


### PR DESCRIPTION
## Description

Change the filename from `general.dart` to `navigation.dart` because it is easier to understand.
Similarly, when moving the screen, change the function name from `navigateScreenNamed` to `push` and `navigateScreen` to `navigate`.

Change the route name from `camelCase` to `kebab-case` referred to the coding convention.
Also support typo safe routing. Define [path] and [fullPath] by attaching extensions to Enum.

The navigation can be done like below.
```
navigation.navigate(context, AppRoute.authSwitch.path);
```
> If you need to pass the props, use [onGenerateRoute][onGenerateRouteLink] to send arguments. This is to follow the official documentation and prevent too many screens from being imported.

[onGenerateRouteLink]:https://docs.flutter.dev/cookbook/navigation/navigate-with-arguments

