### PR TITLE
refactor: migrate `StatefulWidget` to `HookWidget`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
   <application android:name="${applicationName}" android:label="wecount" android:icon="@mipmap/launcher_icon">
-    <meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyAg6X2S4WjIgl_Zkhiz5ZHYW8q-s4fzgRA"/>
+    <meta-data android:name="com.google.android.geo.API_KEY" android:value="@string/geo_api_key"/>
     <activity android:name=".MainActivity" android:exported="true" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
       <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LCXV255WTL;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -399,6 +399,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = wecount;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -407,6 +408,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dooboolab.wecount;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -530,7 +532,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LCXV255WTL;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -538,6 +540,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = wecount;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -546,6 +549,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dooboolab.wecount;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -561,7 +565,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LCXV255WTL;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -569,6 +573,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = wecount;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -577,6 +582,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dooboolab.wecount;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -17,11 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>$(FLUTTER_BUILD_NAME)</string>
+		<!-- <string>$(FLUTTER_BUILD_NAME)</string> -->
+		<string>1</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleVersion</key>
-		<string>$(FLUTTER_BUILD_NUMBER)</string>
+		<!-- <string>$(FLUTTER_BUILD_NUMBER)</string> -->
+		<string>1.0</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>UILaunchStoryboardName</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -17,13 +17,11 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<!-- <string>$(FLUTTER_BUILD_NAME)</string> -->
-		<string>1</string>
+		<string>$(FLUTTER_BUILD_NAME)</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleVersion</key>
-		<!-- <string>$(FLUTTER_BUILD_NUMBER)</string> -->
-		<string>1.0</string>
+		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>UILaunchStoryboardName</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -68,7 +68,7 @@
 				<string>Editor</string>
 				<key>CFBundleURLSchemes</key>
 				<array>
-					<string>com.googleusercontent.apps.221429298568-lhf4eeq02p4bst0ft9gtd65cgqua4ucb</string>
+					<string>com.googleusercontent.apps.764457589810-66l23ggf8l6ilsd157mg4nb0c1k36b0m</string>
 				</array>
 			</dict>
 		</array>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,7 @@ import './utils/localization.dart';
 
 void main() async {
   await _initFire();
-  runApp(MyApp());
+  runApp(const MyApp());
   _fcmListeners();
 }
 
@@ -55,6 +55,7 @@ void _fcmListeners() {
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
   static const supportedLocales = ['en', 'ko'];
 
   @override
@@ -69,6 +70,7 @@ class MyApp extends StatelessWidget {
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
+        initialRoute: AppRoute.authSwitch.fullPath,
         theme: Themes.light,
         darkTheme: Themes.dark,
         routes: routes,
@@ -98,7 +100,7 @@ class MyApp extends StatelessWidget {
           return supportedLocales.first;
         },
         title: appName,
-        home: AuthSwitch(),
+        // home: AuthSwitch(),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,6 +72,7 @@ class MyApp extends StatelessWidget {
         theme: Themes.light,
         darkTheme: Themes.dark,
         routes: routes,
+        onGenerateRoute: onGenerateRoute,
         supportedLocales: [
           const Locale('en', 'US'),
           const Locale('ko', 'KR'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,6 @@ import 'package:wecount/utils/constatns.dart';
 import 'package:wecount/utils/routes.dart';
 import 'package:wecount/utils/themes.dart';
 
-import './navigations/auth_switch.dart' show AuthSwitch;
 import './utils/localization.dart';
 
 void main() async {
@@ -70,21 +69,8 @@ class MyApp extends StatelessWidget {
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        initialRoute: AppRoute.authSwitch.fullPath,
         theme: Themes.light,
         darkTheme: Themes.dark,
-        routes: routes,
-        onGenerateRoute: onGenerateRoute,
-        supportedLocales: [
-          const Locale('en', 'US'),
-          const Locale('ko', 'KR'),
-        ],
-        localizationsDelegates: [
-          const LocalizationDelegate(supportedLocales: ['en', 'ko']),
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
         localeResolutionCallback:
             (Locale? locale, Iterable<Locale> supportedLocales) {
           if (locale == null) {
@@ -99,8 +85,20 @@ class MyApp extends StatelessWidget {
           }
           return supportedLocales.first;
         },
+        localizationsDelegates: [
+          const LocalizationDelegate(supportedLocales: ['en', 'ko']),
+          GlobalMaterialLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: [
+          const Locale('en', 'US'),
+          const Locale('ko', 'KR'),
+        ],
+        initialRoute: AppRoute.authSwitch.fullPath,
+        routes: routes,
+        onGenerateRoute: onGenerateRoute,
         title: appName,
-        // home: AuthSwitch(),
       ),
     );
   }

--- a/lib/navigations/auth_switch.dart
+++ b/lib/navigations/auth_switch.dart
@@ -10,7 +10,7 @@ import 'package:wecount/services/database.dart';
 import 'package:wecount/utils/localization.dart';
 
 class AuthSwitch extends StatelessWidget {
-  static const String name = '/auth_switch';
+  static const String name = '/auth-switch';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/navigations/auth_switch.dart
+++ b/lib/navigations/auth_switch.dart
@@ -10,7 +10,7 @@ import 'package:wecount/services/database.dart';
 import 'package:wecount/utils/localization.dart';
 
 class AuthSwitch extends StatelessWidget {
-  static const String name = '/auth-switch';
+  const AuthSwitch({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:provider/provider.dart';
 
 import 'package:wecount/providers/current_ledger.dart';
@@ -8,18 +9,13 @@ import 'package:wecount/screens/home_statistic/home_statistic.dart'
     show HomeStatistic;
 import 'package:wecount/screens/home_setting.dart' show HomeSetting;
 
-class HomeTab extends StatefulWidget {
+class HomeTab extends HookWidget {
   const HomeTab({Key? key}) : super(key: key);
 
   @override
-  _HomeTabState createState() => _HomeTabState();
-}
-
-class _HomeTabState extends State<HomeTab> {
-  int _index = 0;
-
-  @override
   Widget build(BuildContext context) {
+    var _index = useState<int>(0);
+
     String _title = Provider.of<CurrentLedger>(context).getTitle() ?? '';
 
     return Scaffold(
@@ -27,32 +23,32 @@ class _HomeTabState extends State<HomeTab> {
       body: Stack(
         children: <Widget>[
           Offstage(
-            offstage: _index != 0,
+            offstage: _index.value != 0,
             child: TickerMode(
-              enabled: _index == 0,
+              enabled: _index.value == 0,
               child: HomeCalendar(
                 title: _title,
               ),
             ),
           ),
           Offstage(
-            offstage: _index != 1,
+            offstage: _index.value != 1,
             child: TickerMode(
-              enabled: _index == 1,
+              enabled: _index.value == 1,
               child: HomeList(),
             ),
           ),
           Offstage(
-            offstage: _index != 2,
+            offstage: _index.value != 2,
             child: TickerMode(
-              enabled: _index == 2,
+              enabled: _index.value == 2,
               child: HomeStatistic(title: _title),
             ),
           ),
           Offstage(
-            offstage: _index != 3,
+            offstage: _index.value != 3,
             child: TickerMode(
-              enabled: _index == 3,
+              enabled: _index.value == 3,
               child: HomeSetting(
                 title: _title,
               ),
@@ -62,8 +58,8 @@ class _HomeTabState extends State<HomeTab> {
       ),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.shifting,
-        currentIndex: _index,
-        onTap: (int index) => setState(() => this._index = index),
+        currentIndex: _index.value,
+        onTap: (int index) => _index.value = index,
         selectedItemColor: Theme.of(context).textTheme.displayLarge!.color,
         unselectedItemColor: Theme.of(context).textTheme.displayLarge!.color,
         items: <BottomNavigationBarItem>[

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -9,7 +9,7 @@ import 'package:wecount/screens/home_statistic/home_statistic.dart'
 import 'package:wecount/screens/home_setting.dart' show HomeSetting;
 
 class HomeTab extends StatefulWidget {
-  static const String name = '/home_tab';
+  static const String name = '/home-tab';
 
   HomeTab({Key? key}) : super(key: key);
 

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -25,6 +25,7 @@ class _HomeTabState extends State<HomeTab> {
     String _title = Provider.of<CurrentLedger>(context).getTitle() ?? '';
 
     return Scaffold(
+      // appBar: AppBar(),
       body: Stack(
         children: <Widget>[
           Offstage(

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -9,9 +9,7 @@ import 'package:wecount/screens/home_statistic/home_statistic.dart'
 import 'package:wecount/screens/home_setting.dart' show HomeSetting;
 
 class HomeTab extends StatefulWidget {
-  static const String name = '/home-tab';
-
-  HomeTab({Key? key}) : super(key: key);
+  const HomeTab({Key? key}) : super(key: key);
 
   @override
   _HomeTabState createState() => _HomeTabState();

--- a/lib/screens/category_add.dart
+++ b/lib/screens/category_add.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:wecount/models/category.dart';
 import 'package:wecount/utils/navigation.dart';
@@ -7,7 +8,7 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/db_helper.dart';
 import 'package:wecount/utils/localization.dart';
 
-class CategoryAdd extends StatefulWidget {
+class CategoryAdd extends HookWidget {
   final CategoryType categoryType;
   final int? lastId;
   CategoryAdd({
@@ -16,23 +17,15 @@ class CategoryAdd extends StatefulWidget {
   });
 
   @override
-  _CategoryAddState createState() => _CategoryAddState();
-}
-
-class _CategoryAddState extends State<CategoryAdd> {
-  int? _selectedIconIndex;
-  TextEditingController _textController = TextEditingController();
-  String? _errorText;
-
-  @override
   Widget build(BuildContext context) {
+    final _textController = useTextEditingController();
+    var _selectedIconIndex = useState<int?>(0);
+    var _errorText = useState<String?>("");
     var _localization = Localization.of(context)!;
 
     void onDonePressed() async {
       if (_textController.text == '') {
-        setState(() {
-          _errorText = _localization.trans('ERROR_CATEGORY_NAME');
-        });
+        _errorText.value = _localization.trans('ERROR_CATEGORY_NAME');
         return;
       }
       if (_selectedIconIndex == null) {
@@ -44,10 +37,10 @@ class _CategoryAddState extends State<CategoryAdd> {
         return;
       }
       Category category = Category(
-        id: widget.lastId! + 1,
-        iconId: _selectedIconIndex,
+        id: lastId! + 1,
+        iconId: _selectedIconIndex.value,
         label: _textController.text,
-        type: widget.categoryType,
+        type: categoryType,
       );
 
       try {
@@ -85,9 +78,7 @@ class _CategoryAddState extends State<CategoryAdd> {
                           padding: EdgeInsets.only(left: 8, bottom: 8),
                           child: InkWell(
                             onTap: () {
-                              setState(() {
-                                _selectedIconIndex = i;
-                              });
+                              _selectedIconIndex.value = i;
                             },
                             child: Opacity(
                               opacity: i == _selectedIconIndex ? 1.0 : 0.4,
@@ -144,7 +135,7 @@ class _CategoryAddState extends State<CategoryAdd> {
                         right: 24,
                       ),
                       hintText: _localization.trans('CATEGORY_ADD_HINT'),
-                      errorText: _errorText,
+                      errorText: _errorText.value,
                     ),
                     Container(
                       child: Row(

--- a/lib/screens/category_add.dart
+++ b/lib/screens/category_add.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:wecount/models/category.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/edit_text_box.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/db_helper.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 
 class CategoryAdd extends StatefulWidget {
@@ -36,7 +36,7 @@ class _CategoryAddState extends State<CategoryAdd> {
         return;
       }
       if (_selectedIconIndex == null) {
-        General.instance.showSingleDialog(
+        navigation.showSingleDialog(
           context,
           title: Text(_localization.trans('ERROR')!),
           content: Text(_localization.trans('ERROR_CATEGORY_ICON')!),

--- a/lib/screens/find_pw.dart
+++ b/lib/screens/find_pw.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/edit_text.dart' show EditText;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/validator.dart' show Validator;
@@ -10,7 +10,7 @@ import 'package:wecount/utils/validator.dart' show Validator;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 
 class FindPw extends StatefulWidget {
-  static const String name = '/find_pw';
+  static const String name = '/find-pw';
 
   FindPw({Key? key}) : super(key: key);
 
@@ -38,7 +38,7 @@ class _FindPwState extends State<FindPw> {
 
     try {
       await _auth.sendPasswordResetEmail(email: _email);
-      General.instance.showSingleDialog(
+      navigation.showSingleDialog(
         context,
         title: Text(_localization!.trans('SUCCESS')!),
         content: Text(_localization!.trans('PASSWORD_RESET_LINK_SENT')!),

--- a/lib/screens/find_pw.dart
+++ b/lib/screens/find_pw.dart
@@ -10,9 +10,7 @@ import 'package:wecount/utils/validator.dart' show Validator;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 
 class FindPw extends StatefulWidget {
-  static const String name = '/find-pw';
-
-  FindPw({Key? key}) : super(key: key);
+  const FindPw({Key? key}) : super(key: key);
 
   @override
   _FindPwState createState() => _FindPwState();

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -50,7 +50,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () => navigation.push(context, Ledgers.name),
+                  onPressed: () => navigation.push(context, 'ledgers'),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,
@@ -63,7 +63,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
                   onPressed: () =>
-                      Navigator.of(context).pushNamed(LedgerItemEdit.name),
+                      Navigator.of(context).pushNamed("/ledger-item-edit"),
                   child: Icon(
                     Icons.add,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -4,6 +4,7 @@ import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/screens/ledger_item_edit.dart';
 import 'package:wecount/screens/ledgers.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/widgets/home_list_item.dart';
 import 'package:wecount/types/color.dart';
@@ -50,7 +51,8 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () => navigation.push(context, 'ledgers'),
+                  onPressed: () =>
+                      navigation.push(context, AppRoute.ledgers.fullPath),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,
@@ -62,8 +64,8 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () =>
-                      Navigator.of(context).pushNamed("/ledger-item-edit"),
+                  onPressed: () => Navigator.of(context)
+                      .pushNamed(AppRoute.ledgerItemEdit.fullPath),
                   child: Icon(
                     Icons.add,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -3,6 +3,7 @@ import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/screens/ledger_item_edit.dart';
 import 'package:wecount/screens/ledgers.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/widgets/home_list_item.dart';
 import 'package:wecount/types/color.dart';
@@ -10,7 +11,6 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:flutter/material.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/widgets/home_header.dart' show HomeHeaderExpanded;
 import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart'
     show CalendarCarousel;
@@ -50,8 +50,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () => General.instance
-                      .navigateScreenNamed(context, Ledgers.name),
+                  onPressed: () => navigation.push(context, Ledgers.name),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -2,8 +2,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/mocks/home_calendar.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
-import 'package:wecount/screens/ledger_item_edit.dart';
-import 'package:wecount/screens/ledgers.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -23,7 +23,7 @@ import 'package:provider/provider.dart';
 class HomeCalendar extends StatefulWidget {
   HomeCalendar({
     Key? key,
-    this.title = '2017 Bookoo',
+    this.title = '2022 WeCount',
   }) : super(key: key);
   final String title;
 
@@ -52,7 +52,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
                   onPressed: () =>
-                      navigation.push(context, AppRoute.ledgers.fullPath),
+                      navigation.push(context, AppRoute.ledgers.path),
                   child: Icon(
                     Icons.book,
                     color: Colors.white,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/mocks/home_calendar.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
@@ -20,18 +21,13 @@ import 'package:flutter_calendar_carousel/classes/event_list.dart';
 import 'package:intl/intl.dart' show DateFormat;
 import 'package:provider/provider.dart';
 
-class HomeCalendar extends StatefulWidget {
+class HomeCalendar extends HookWidget {
   HomeCalendar({
     Key? key,
     this.title = '2022 WeCount',
   }) : super(key: key);
   final String title;
 
-  @override
-  _HomeCalendarState createState() => _HomeCalendarState();
-}
-
-class _HomeCalendarState extends State<HomeCalendar> {
   @override
   Widget build(BuildContext context) {
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
@@ -43,7 +39,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
       body: CustomScrollView(
         slivers: <Widget>[
           HomeHeaderExpanded(
-            title: widget.title,
+            title: title,
             color: Asset.Colors.getColor(color),
             actions: [
               Container(
@@ -85,84 +81,75 @@ class _HomeCalendarState extends State<HomeCalendar> {
   }
 }
 
-class MyHomePage extends StatefulWidget {
+class MyHomePage extends HookWidget {
   MyHomePage({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  DateTime? _currentDate;
-  DateTime? _targetDate;
-  String _currentMonth = '';
-
-  EventList<Event>? _markedDateMap;
-
-  /// ledgerList from parents
-  List<LedgerItem> _ledgerList = [];
-
-  /// for bottom list UI
-  List<LedgerItem> _ledgerListOfSelectedDate = [];
-
-  void selectDate(
-    DateTime date,
-  ) {
-    _ledgerListOfSelectedDate.clear();
-    _ledgerList.forEach((item) {
-      if (item.selectedDate == date) {
-        _ledgerListOfSelectedDate.add(item);
-      }
-    });
-    setState(() {
-      _currentDate = date;
-      _targetDate = DateTime(date.year, date.month);
-      _currentMonth = DateFormat.yMMM().format(date);
-    });
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _currentDate = DateTime.now();
-    _targetDate = DateTime.now();
-    _currentMonth = DateFormat.yMMM().format(_currentDate!);
-
-    Future.delayed(Duration.zero, () {
-      var _localization = Localization.of(context)!;
-
-      List<LedgerItem> ledgerList = createCalendarLedgerItemMock(_localization);
-      EventList<Event>? markedDateMap = EventList(events: {});
-      ledgerList.forEach((ledger) {
-        markedDateMap.add(ledger.selectedDate!,
-            Event(date: ledger.selectedDate!, title: ledger.category!.label));
-      });
-
-      this.setState(() {
-        this._ledgerList = ledgerList;
-        this._markedDateMap = markedDateMap;
-      });
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _currentDate = useState<DateTime?>(DateTime.now());
+    var _targetDate = useState<DateTime?>(DateTime.now());
+    var _currentMonth = useState<String>("");
+
+    var _markedDateMap = useState<EventList<Event>?>(null);
+
+    /// ledgerList from parents
+    var _ledgerList = useState<List<LedgerItem>>([]);
+
+    /// for bottom list UI
+    List<LedgerItem> _ledgerListOfSelectedDate = [];
+
+    void selectDate(
+      DateTime date,
+    ) {
+      _ledgerListOfSelectedDate.clear();
+      _ledgerList.value.forEach((item) {
+        if (item.selectedDate == date) {
+          _ledgerListOfSelectedDate.add(item);
+        }
+      });
+      _currentDate.value = date;
+      _targetDate.value = DateTime(date.year, date.month);
+      _currentMonth.value = DateFormat.yMMM().format(date);
+    }
+
+    useEffect(() {
+      _currentDate.value = DateTime.now();
+      _targetDate.value = DateTime.now();
+      _currentMonth.value = DateFormat.yMMM().format(_currentDate.value!);
+
+      Future.delayed(Duration.zero, () {
+        var _localization = Localization.of(context)!;
+
+        List<LedgerItem> ledgerList =
+            createCalendarLedgerItemMock(_localization);
+        EventList<Event>? markedDateMap = EventList(events: {});
+        ledgerList.forEach((ledger) {
+          markedDateMap.add(ledger.selectedDate!,
+              Event(date: ledger.selectedDate!, title: ledger.category!.label));
+        });
+
+        _ledgerList.value = ledgerList;
+        _markedDateMap.value = markedDateMap;
+      });
+      return null;
+    }, []);
+
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;
 
     void onDatePressed() async {
-      int year = this._currentDate!.year;
+      int year = _currentDate.value!.year;
       int prevDate = year - 100;
       int lastDate = year + 10;
       DateTime? pickDate = await showDatePicker(
         context: context,
-        initialDate: this._currentDate!,
+        initialDate: _currentDate.value!,
         firstDate: DateTime(prevDate),
         lastDate: DateTime(lastDate),
       );
       if (pickDate != null) {
-        this.selectDate(pickDate);
+        selectDate(pickDate);
       }
     }
 
@@ -173,23 +160,21 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           children: <Widget>[
             DateSelector(
-              date: this._currentMonth,
+              date: _currentMonth.value,
               onDatePressed: onDatePressed,
             ),
             renderCalendar(
                 context: context,
                 onCalendarChanged: (DateTime date) {
-                  this.setState(() {
-                    _currentMonth = DateFormat.yMMM().format(date);
-                    _targetDate = date;
-                  });
+                  _currentMonth.value = DateFormat.yMMM().format(date);
+                  _targetDate.value = date;
                 },
                 onDayPressed: (DateTime date, List<Event> events) {
-                  this.selectDate(date);
+                  selectDate(date);
                 },
-                markedDateMap: _markedDateMap,
-                currentDate: _currentDate,
-                targetDate: _targetDate,
+                markedDateMap: _markedDateMap.value,
+                currentDate: _currentDate.value,
+                targetDate: _targetDate.value,
                 color: Asset.Colors.getColor(color)),
             Divider(
               color: Colors.grey,

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -38,7 +38,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
         : ColorType.DUSK;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: CustomScrollView(
         slivers: <Widget>[
           HomeHeaderExpanded(

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -30,45 +30,6 @@ class HomeList extends HookWidget {
     var _data = [];
     var _listData = useState([]);
 
-    Widget _renderListHeader(DateTime date) {
-      String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
-      return Container(
-        color: Colors.white,
-        height: 60.0,
-        padding: EdgeInsets.only(
-          top: 16.0,
-          left: 10.0,
-        ),
-        // padding: EdgeInsets.symmetric(horizontal: 16.0),
-        alignment: Alignment.centerLeft,
-        child: Text(
-          headerString,
-          style: TextStyle(
-            fontSize: 16,
-            color: Theme.of(context).textTheme.displayMedium!.color,
-          ),
-        ),
-      );
-    }
-
-    List<Widget> _renderList(BuildContext context) {
-      return List.generate(_listData.value.length, (index) {
-        var section = _listData.value[index];
-        var headerDate = section['date'];
-        var ledgerItems = section['ledgerItems'];
-        return SliverStickyHeader(
-          header: _renderListHeader(headerDate),
-          sliver: SliverList(
-            key: Key(index.toString()),
-            delegate: SliverChildBuilderDelegate(
-              (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
-              childCount: ledgerItems.length,
-            ),
-          ),
-        );
-      });
-    }
-
     // List<List<LedgerItem>> _ledgerItems = [[]];
     useEffect(() {
       Future.delayed(Duration.zero, () {
@@ -253,7 +214,6 @@ class HomeList extends HookWidget {
             selectedDate: DateTime(2019, 9, 4),
           ),
         );
-
         // sort data
         _data.sort((a, b) {
           return a.selectedDate.compareTo(b.selectedDate);
@@ -286,6 +246,45 @@ class HomeList extends HookWidget {
       });
       return null;
     }, []);
+
+    Widget _renderListHeader(DateTime date) {
+      String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
+      return Container(
+        height: 60.0,
+        color: Colors.white,
+        padding: EdgeInsets.only(
+          top: 16.0,
+          left: 10.0,
+        ),
+        // padding: EdgeInsets.symmetric(horizontal: 16.0),
+        alignment: Alignment.centerLeft,
+        child: Text(
+          headerString,
+          style: TextStyle(
+            fontSize: 16,
+            color: Theme.of(context).textTheme.displayMedium!.color,
+          ),
+        ),
+      );
+    }
+
+    List<Widget> _renderList(BuildContext context) {
+      return List.generate(_listData.value.length, (index) {
+        var section = _listData.value[index];
+        var headerDate = section['date'];
+        var ledgerItems = section['ledgerItems'];
+        return SliverStickyHeader(
+          header: _renderListHeader(headerDate),
+          sliver: SliverList(
+            key: Key(index.toString()),
+            delegate: SliverChildBuilderDelegate(
+              (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
+              childCount: ledgerItems.length,
+            ),
+          ),
+        );
+      });
+    }
 
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
         ? Provider.of<CurrentLedger>(context).getLedger()!.color

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
@@ -17,280 +18,275 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:provider/provider.dart';
 
-class HomeList extends StatefulWidget {
+class HomeList extends HookWidget {
   HomeList({
     Key? key,
   }) : super(key: key);
 
   @override
-  _HomeListState createState() => _HomeListState();
-}
+  Widget build(BuildContext context) {
+    final textEditingController = useTextEditingController();
 
-class _HomeListState extends State<HomeList> {
-  TextEditingController textEditingController = TextEditingController();
+    var _data = [];
+    var _listData = useState([]);
 
-  var _data = [];
-  var _listData = [];
-
-  // List<List<LedgerItem>> _ledgerItems = [[]];
-  @override
-  void initState() {
-    super.initState();
-    Future.delayed(Duration.zero, () {
-      var _localization = Localization.of(context)!;
-
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 8,
-              label: _localization.trans('EXERCISE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 10),
+    Widget _renderListHeader(DateTime date) {
+      String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
+      return Container(
+        color: Colors.white,
+        height: 60.0,
+        padding: EdgeInsets.only(
+          top: 16.0,
+          left: 10.0,
         ),
-      );
-      _data.add(
-        LedgerItem(
-          price: 300000,
-          category: Category(
-              iconId: 18,
-              label: _localization.trans('WALLET_MONEY'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 10),
-        ),
-      );
-
-      _data.add(
-        LedgerItem(
-          price: -32000,
-          category: Category(
-              iconId: 4,
-              label: _localization.trans('DATING'),
-              type: CategoryType.CONSUME),
-          memo: 'who1 gave me',
-          writer: User(uid: 'who1@gmail.com', displayName: 'engela lee'),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: 300000,
-          category: Category(
-              iconId: 18,
-              label: _localization.trans('WALLET_MONEY'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 12,
-              label: _localization.trans('PRESENT'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-
-      _data.add(
-        LedgerItem(
-          price: -32000,
-          category: Category(
-              iconId: 4,
-              label: _localization.trans('DATING'),
-              type: CategoryType.CONSUME),
-          memo: 'who1 gave me',
-          writer: User(uid: 'who1@gmail.com', displayName: '이범주'),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 12,
-              label: _localization.trans('PRESENT'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-
-      _data.add(
-        LedgerItem(
-          price: -32000,
-          category: Category(
-              iconId: 4,
-              label: _localization.trans('DATING'),
-              type: CategoryType.CONSUME),
-          memo: 'who1 gave me',
-          writer: User(uid: 'who1@gmail.com', displayName: 'mizcom'),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 4),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -2100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 4),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 12,
-              label: _localization.trans('PRESENT'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 4),
-        ),
-      );
-
-      // sort data
-      _data.sort((a, b) {
-        return a.selectedDate.compareTo(b.selectedDate);
-      });
-
-      // insert Date row as Header
-      DateTime? prevDate;
-      var temp = [];
-      for (var i = 0; i < _data.length; i++) {
-        if (prevDate != _data[i].selectedDate) {
-          // 다르면 모은 데이터를 저장하고, 모음 리셋
-          if (temp.length > 0) {
-            _listData.add({
-              'date': prevDate,
-              'ledgerItems': temp,
-            });
-          }
-          prevDate = _data[i].selectedDate;
-          temp = [];
-        }
-        temp.add(_data[i]); // 데이터 임시 모음
-        // _listData.add(_data[i]);
-      }
-      if (temp.length > 0) {
-        _listData.add({
-          'date': prevDate,
-          'ledgerItems': temp,
-        });
-      }
-    });
-  }
-
-  Widget _renderListHeader(DateTime date) {
-    String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
-    return Container(
-      height: 60.0,
-      padding: EdgeInsets.only(
-        top: 16.0,
-        left: 10.0,
-      ),
-      // padding: EdgeInsets.symmetric(horizontal: 16.0),
-      alignment: Alignment.centerLeft,
-      child: Text(
-        headerString,
-        style: TextStyle(
-          fontSize: 16,
-          color: Theme.of(context).textTheme.displayMedium!.color,
-        ),
-      ),
-    );
-  }
-
-  List<Widget> _renderList(BuildContext context) {
-    return List.generate(_listData.length, (index) {
-      var section = _listData[index];
-      var headerDate = section['date'];
-      var ledgerItems = section['ledgerItems'];
-      return SliverStickyHeader(
-        header: _renderListHeader(headerDate),
-        sliver: SliverList(
-          key: Key(index.toString()),
-          delegate: SliverChildBuilderDelegate(
-            (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
-            childCount: ledgerItems.length,
+        // padding: EdgeInsets.symmetric(horizontal: 16.0),
+        alignment: Alignment.centerLeft,
+        child: Text(
+          headerString,
+          style: TextStyle(
+            fontSize: 16,
+            color: Theme.of(context).textTheme.displayMedium!.color,
           ),
         ),
       );
-    });
-  }
+    }
 
-  @override
-  Widget build(BuildContext context) {
+    List<Widget> _renderList(BuildContext context) {
+      return List.generate(_listData.value.length, (index) {
+        var section = _listData.value[index];
+        var headerDate = section['date'];
+        var ledgerItems = section['ledgerItems'];
+        return SliverStickyHeader(
+          header: _renderListHeader(headerDate),
+          sliver: SliverList(
+            key: Key(index.toString()),
+            delegate: SliverChildBuilderDelegate(
+              (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
+              childCount: ledgerItems.length,
+            ),
+          ),
+        );
+      });
+    }
+
+    // List<List<LedgerItem>> _ledgerItems = [[]];
+    useEffect(() {
+      Future.delayed(Duration.zero, () {
+        var _localization = Localization.of(context)!;
+
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 8,
+                label: _localization.trans('EXERCISE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 10),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: 300000,
+            category: Category(
+                iconId: 18,
+                label: _localization.trans('WALLET_MONEY'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 10),
+          ),
+        );
+
+        _data.add(
+          LedgerItem(
+            price: -32000,
+            category: Category(
+                iconId: 4,
+                label: _localization.trans('DATING'),
+                type: CategoryType.CONSUME),
+            memo: 'who1 gave me',
+            writer: User(uid: 'who1@gmail.com', displayName: 'engela lee'),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: 300000,
+            category: Category(
+                iconId: 18,
+                label: _localization.trans('WALLET_MONEY'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 12,
+                label: _localization.trans('PRESENT'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+
+        _data.add(
+          LedgerItem(
+            price: -32000,
+            category: Category(
+                iconId: 4,
+                label: _localization.trans('DATING'),
+                type: CategoryType.CONSUME),
+            memo: 'who1 gave me',
+            writer: User(uid: 'who1@gmail.com', displayName: '이범주'),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 12,
+                label: _localization.trans('PRESENT'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+
+        _data.add(
+          LedgerItem(
+            price: -32000,
+            category: Category(
+                iconId: 4,
+                label: _localization.trans('DATING'),
+                type: CategoryType.CONSUME),
+            memo: 'who1 gave me',
+            writer: User(uid: 'who1@gmail.com', displayName: 'mizcom'),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 4),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -2100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 4),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 12,
+                label: _localization.trans('PRESENT'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 4),
+          ),
+        );
+
+        // sort data
+        _data.sort((a, b) {
+          return a.selectedDate.compareTo(b.selectedDate);
+        });
+
+        // insert Date row as Header
+        DateTime? prevDate;
+        var temp = [];
+        for (var i = 0; i < _data.length; i++) {
+          if (prevDate != _data[i].selectedDate) {
+            // 다르면 모은 데이터를 저장하고, 모음 리셋
+            if (temp.length > 0) {
+              _listData.value.add({
+                'date': prevDate,
+                'ledgerItems': temp,
+              });
+            }
+            prevDate = _data[i].selectedDate;
+            temp = [];
+          }
+          temp.add(_data[i]); // 데이터 임시 모음
+          // _listData.add(_data[i]);
+        }
+        if (temp.length > 0) {
+          _listData.value.add({
+            'date': prevDate,
+            'ledgerItems': temp,
+          });
+        }
+      });
+      return null;
+    }, []);
+
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -3,6 +3,7 @@ import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/home_header_search.dart' show HomeHeaderSearch;
 import 'package:wecount/models/category.dart';
@@ -295,7 +296,7 @@ class _HomeListState extends State<HomeList> {
         : ColorType.DUSK;
 
     Function onAddLedgerList =
-        () => navigation.push(context, 'ledger-item-edit');
+        () => navigation.push(context, AppRoute.ledgerItemEdit.fullPath);
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -1,7 +1,10 @@
+import 'package:flat_list/flat_list.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/models/user.dart';
+import 'package:wecount/utils/logger.dart';
 
 import 'package:wecount/widgets/home_header_search.dart' show HomeHeaderSearch;
 import 'package:wecount/models/category.dart';
@@ -298,17 +301,19 @@ class _HomeListState extends State<HomeList> {
         General.instance.navigateScreenNamed(context, '/ledger_item_edit');
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
+        toolbarHeight: 100,
         automaticallyImplyLeading: false,
         titleSpacing: 0.0,
+        backgroundColor: Asset.Colors.getColor(color),
         title: HomeHeaderSearch(
           color: Asset.Colors.getColor(color),
           margin: EdgeInsets.only(left: 20.0),
           textEditingController: textEditingController,
           actions: <Widget>[
             Container(
-              width: 56.0,
+              width: 50.0,
               child: RawMaterialButton(
                 padding: EdgeInsets.all(0.0),
                 shape: CircleBorder(),
@@ -325,8 +330,25 @@ class _HomeListState extends State<HomeList> {
       body: SafeArea(
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: 16),
-          child: CustomScrollView(
-            slivers: _renderList(context),
+          child: FlatList(
+            data: _listData,
+            buildItem: (item, index) {
+              var section = _listData[index];
+              var headerDate = section['date'];
+              var ledgerItems = section['ledgerItems'];
+              return Column(
+                children: [
+                  _renderListHeader(headerDate),
+                  ...ledgerItems
+                      .map<Widget>(
+                        (val) => HomeListItem(
+                          ledgerItem: val,
+                        ),
+                      )
+                      .toList()
+                ],
+              );
+            },
           ),
         ),
       ),

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -295,9 +295,6 @@ class _HomeListState extends State<HomeList> {
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;
 
-    Function onAddLedgerList =
-        () => navigation.push(context, AppRoute.ledgerItemEdit.fullPath);
-
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
@@ -306,23 +303,12 @@ class _HomeListState extends State<HomeList> {
         titleSpacing: 0.0,
         backgroundColor: Asset.Colors.getColor(color),
         title: HomeHeaderSearch(
+          onPressAdd: () =>
+              navigation.push(context, AppRoute.ledgerItemEdit.path),
+          onPressDelete: () => textEditingController.clear(),
           color: Asset.Colors.getColor(color),
           margin: EdgeInsets.only(left: 20.0),
           textEditingController: textEditingController,
-          actions: <Widget>[
-            Container(
-              width: 50.0,
-              child: RawMaterialButton(
-                padding: EdgeInsets.all(0.0),
-                shape: CircleBorder(),
-                onPressed: onAddLedgerList as void Function()?,
-                child: Icon(
-                  Icons.add,
-                  color: Colors.white,
-                ),
-              ),
-            ),
-          ],
         ),
       ),
       body: SafeArea(

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -295,7 +295,7 @@ class _HomeListState extends State<HomeList> {
         : ColorType.DUSK;
 
     Function onAddLedgerList =
-        () => navigation.push(context, 'ledger_item_edit');
+        () => navigation.push(context, 'ledger-item-edit');
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -326,10 +326,11 @@ class _HomeListState extends State<HomeList> {
       ),
       body: SafeArea(
         child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16),
-            child: CustomScrollView(
-              slivers: _renderList(context),
-            )),
+          padding: EdgeInsets.symmetric(horizontal: 16),
+          child: CustomScrollView(
+            slivers: _renderList(context),
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -1,17 +1,14 @@
-import 'package:flat_list/flat_list.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/models/user.dart';
-import 'package:wecount/utils/logger.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/home_header_search.dart' show HomeHeaderSearch;
 import 'package:wecount/models/category.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/widgets/home_list_item.dart';
 
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:intl/intl.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
@@ -297,8 +294,8 @@ class _HomeListState extends State<HomeList> {
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;
 
-    Function onAddLedgerList = () =>
-        General.instance.navigateScreenNamed(context, '/ledger_item_edit');
+    Function onAddLedgerList =
+        () => navigation.push(context, 'ledger_item_edit');
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -329,28 +326,10 @@ class _HomeListState extends State<HomeList> {
       ),
       body: SafeArea(
         child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 16),
-          child: FlatList(
-            data: _listData,
-            buildItem: (item, index) {
-              var section = _listData[index];
-              var headerDate = section['date'];
-              var ledgerItems = section['ledgerItems'];
-              return Column(
-                children: [
-                  _renderListHeader(headerDate),
-                  ...ledgerItems
-                      .map<Widget>(
-                        (val) => HomeListItem(
-                          ledgerItem: val,
-                        ),
-                      )
-                      .toList()
-                ],
-              );
-            },
-          ),
-        ),
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            child: CustomScrollView(
+              slivers: _renderList(context),
+            )),
       ),
     );
   }

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -1,6 +1,4 @@
 import 'package:wecount/providers/current_ledger.dart';
-import 'package:wecount/screens/setting_currency.dart';
-import 'package:wecount/screens/setting_excel.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -42,8 +40,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () =>
-            navigation.push(context, AppRoute.settingCurrency.fullPath),
+        onTap: () => navigation.push(context, AppRoute.settingCurrency.path),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -53,7 +50,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, AppRoute.settingExcel.fullPath),
+        onTap: () => navigation.push(context, AppRoute.settingExcel.path),
       ),
     ];
 

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -41,7 +41,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, SettingCurrency.name),
+        onTap: () => navigation.push(context, "setting_currency"),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -51,7 +51,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, SettingExcel.name),
+        onTap: () => navigation.push(context, "setting-excel"),
       ),
     ];
 

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
@@ -12,18 +13,13 @@ import '../widgets/setting_list_item.dart'
     show ListItem, TileItem, SettingTileItem;
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
-class HomeSetting extends StatefulWidget {
+class HomeSetting extends HookWidget {
   HomeSetting({
     Key? key,
     this.title = '',
   }) : super(key: key);
   final String title;
 
-  @override
-  _HomeSettingState createState() => _HomeSettingState();
-}
-
-class _HomeSettingState extends State<HomeSetting> {
   @override
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
@@ -57,7 +53,7 @@ class _HomeSettingState extends State<HomeSetting> {
     return Scaffold(
       appBar: renderHomeAppBar(
         context: context,
-        title: widget.title,
+        title: title,
         color: Asset.Colors.getColor(color),
         fontColor: Colors.white,
       ),

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -64,7 +64,7 @@ class _HomeSettingState extends State<HomeSetting> {
         color: Asset.Colors.getColor(color),
         fontColor: Colors.white,
       ),
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Column(
           children: <Widget>[

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -5,6 +5,7 @@ import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import '../utils/asset.dart' as Asset;
 import '../utils/localization.dart' show Localization;
@@ -41,7 +42,8 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, "setting_currency"),
+        onTap: () =>
+            navigation.push(context, AppRoute.settingCurrency.fullPath),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -51,7 +53,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () => navigation.push(context, "setting-excel"),
+        onTap: () => navigation.push(context, AppRoute.settingExcel.fullPath),
       ),
     ];
 

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -4,8 +4,8 @@ import 'package:wecount/screens/setting_excel.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:wecount/utils/navigation.dart';
 
-import '../utils/general.dart' show General;
 import '../utils/asset.dart' as Asset;
 import '../utils/localization.dart' show Localization;
 
@@ -41,8 +41,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () =>
-            General.instance.navigateScreenNamed(context, SettingCurrency.name),
+        onTap: () => navigation.push(context, SettingCurrency.name),
       ),
       TileItem(
         title: _localization.trans('EXPORT_EXCEL'),
@@ -52,8 +51,7 @@ class _HomeSettingState extends State<HomeSetting> {
           color: Asset.Colors.cloudyBlue,
           size: 24.0,
         ),
-        onTap: () =>
-            General.instance.navigateScreenNamed(context, SettingExcel.name),
+        onTap: () => navigation.push(context, SettingExcel.name),
       ),
     ];
 

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -77,10 +77,10 @@ class Content extends HookWidget {
 
     /// State
     DateTime _date = DateTime.now();
-    Map<String, double>? _dataMapIncome = Map();
-    Map<String, double>? _dataMapExpense = Map();
-    var _condensedLedgerList = useState<List<LedgerItem>>([]).value;
-    var _selectedChart = useState<int?>(null).value;
+    var _dataMapIncome = useState<Map<String, double>?>(Map());
+    var _dataMapExpense = useState<Map<String, double>?>(Map());
+    var _condensedLedgerList = useState<List<LedgerItem>>([]);
+    var _selectedChart = useState<int?>(null);
 
     List<Color> colorList = [
       Asset.Colors.blue,
@@ -100,9 +100,9 @@ class Content extends HookWidget {
       var result = splitLedgers(condensedLedgerList);
       // ledgerList.addAll(normalIncomeList(localization, 10));
 
-      _condensedLedgerList = condensedLedgerList;
-      _dataMapIncome = result['income'];
-      _dataMapExpense = result['expense'];
+      _condensedLedgerList.value = condensedLedgerList;
+      _dataMapIncome.value = result['income'];
+      _dataMapExpense.value = result['expense'];
     }
 
     ;
@@ -114,7 +114,7 @@ class Content extends HookWidget {
         _ledgerList = createHomeStatisticMock(Localization.of(context)!);
 
         calculateAndRender(_date.month.toString(), _ledgerList);
-        _selectedChart = 1;
+        _selectedChart.value = 1;
       });
       return null;
     }, []);
@@ -136,8 +136,9 @@ class Content extends HookWidget {
       // }
     }
 
-    Map<String, double> dataMap =
-        _selectedChart == 1 ? _dataMapIncome! : _dataMapExpense!;
+    Map<String, double> dataMap = _selectedChart.value == 1
+        ? _dataMapIncome.value!
+        : _dataMapExpense.value!;
 
     /// PieChart throws error when `_dataMap` is empty
     var chartWidget = dataMap.length > 0
@@ -167,7 +168,7 @@ class Content extends HookWidget {
                 ),
                 Text(
                   localization!.trans('NO_DATA')!,
-                  style: TextStyle(),
+                  style: TextStyle(color: Colors.black),
                 ),
               ],
               direction: Axis.vertical,
@@ -180,9 +181,9 @@ class Content extends HookWidget {
       shrinkWrap: true,
       physics: NeverScrollableScrollPhysics(),
       padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-      itemCount: _condensedLedgerList.length,
+      itemCount: _condensedLedgerList.value.length,
       itemBuilder: (BuildContext context, int index) {
-        return HomeListItem(ledgerItem: _condensedLedgerList[index]);
+        return HomeListItem(ledgerItem: _condensedLedgerList.value[index]);
       },
     );
 
@@ -204,10 +205,10 @@ class Content extends HookWidget {
             ),
             ButtonGroup(
               onButtonOnePressed: () {
-                _selectedChart = 1;
+                _selectedChart.value = 1;
               },
               onButtonTwoPressed: () {
-                _selectedChart = 2;
+                _selectedChart.value = 2;
               },
               selected: _selectedChart,
             ),

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -45,7 +45,7 @@ class HomeStatistic extends StatelessWidget {
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
               onPressed: () =>
-                  navigation.push(context, AppRoute.ledgerItemEdit.fullPath),
+                  navigation.push(context, AppRoute.ledgerItemEdit.path),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -2,6 +2,7 @@ import 'package:wecount/mocks/home_statistic.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/screens/home_statistic/functions.dart';
 
@@ -43,7 +44,8 @@ class HomeStatistic extends StatelessWidget {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, 'ledger-item-edit'),
+              onPressed: () =>
+                  navigation.push(context, AppRoute.ledgerItemEdit.fullPath),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -168,7 +168,7 @@ class Content extends HookWidget {
                 ),
                 Text(
                   localization!.trans('NO_DATA')!,
-                  style: TextStyle(color: Colors.black),
+                  style: TextStyle(),
                 ),
               ],
               direction: Axis.vertical,
@@ -210,7 +210,7 @@ class Content extends HookWidget {
               onButtonTwoPressed: () {
                 _selectedChart.value = 2;
               },
-              selected: _selectedChart,
+              selected: _selectedChart.value,
             ),
             chartWidget,
             bottomListWidget,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -43,7 +43,7 @@ class HomeStatistic extends StatelessWidget {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, 'ledger_item_edit'),
+              onPressed: () => navigation.push(context, 'ledger-item-edit'),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/mocks/home_statistic.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
@@ -66,67 +67,61 @@ class HomeStatistic extends StatelessWidget {
   }
 }
 
-class Content extends StatefulWidget {
+class Content extends HookWidget {
   Content({Key? key}) : super(key: key);
 
   @override
-  _ContentState createState() => _ContentState();
-}
-
-class _ContentState extends State<Content> {
-  /// From parent
-  late List<LedgerItem> _ledgerList;
-
-  /// State
-  DateTime _date = DateTime.now();
-  List<LedgerItem> _condensedLedgerList = [];
-  Map<String, double>? _dataMapIncome = Map();
-  Map<String, double>? _dataMapExpense = Map();
-  int? _selectedChart;
-
-  List<Color> colorList = [
-    Asset.Colors.blue,
-    Asset.Colors.orange,
-    Asset.Colors.green,
-    Asset.Colors.yellow,
-    Asset.Colors.purple,
-    Asset.Colors.main,
-    Asset.Colors.red,
-  ];
-
-  @override
-  void initState() {
-    super.initState();
-    Future.delayed(Duration.zero, () {
-      _ledgerList = createHomeStatisticMock(Localization.of(context)!);
-
-      calculateAndRender(this._date.month.toString(), _ledgerList);
-      this.setState(() => this._selectedChart = 1);
-    });
-  }
-
-  void calculateAndRender(String month, List<LedgerItem> ledgerList) {
-    var ledgerListOfSelectedMonth = ledgerListByMonth(month, ledgerList);
-
-    /// sum up same category into one. but before that I can make ui first
-    var condensedLedgerList = condense(ledgerListOfSelectedMonth);
-    var result = splitLedgers(condensedLedgerList);
-    // ledgerList.addAll(normalIncomeList(localization, 10));
-
-    this.setState(() {
-      this._condensedLedgerList = condensedLedgerList;
-      this._dataMapIncome = result['income'];
-      this._dataMapExpense = result['expense'];
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
+    /// From parent
+    late List<LedgerItem> _ledgerList;
+
+    /// State
+    DateTime _date = DateTime.now();
+    Map<String, double>? _dataMapIncome = Map();
+    Map<String, double>? _dataMapExpense = Map();
+    var _condensedLedgerList = useState<List<LedgerItem>>([]).value;
+    var _selectedChart = useState<int?>(null).value;
+
+    List<Color> colorList = [
+      Asset.Colors.blue,
+      Asset.Colors.orange,
+      Asset.Colors.green,
+      Asset.Colors.yellow,
+      Asset.Colors.purple,
+      Asset.Colors.main,
+      Asset.Colors.red,
+    ];
+
+    void calculateAndRender(String month, List<LedgerItem> ledgerList) {
+      var ledgerListOfSelectedMonth = ledgerListByMonth(month, ledgerList);
+
+      /// sum up same category into one. but before that I can make ui first
+      var condensedLedgerList = condense(ledgerListOfSelectedMonth);
+      var result = splitLedgers(condensedLedgerList);
+      // ledgerList.addAll(normalIncomeList(localization, 10));
+
+      _condensedLedgerList = condensedLedgerList;
+      _dataMapIncome = result['income'];
+      _dataMapExpense = result['expense'];
+    }
+
+    ;
+
     var localization = Localization.of(context);
+
+    useEffect(() {
+      Future.delayed(Duration.zero, () {
+        _ledgerList = createHomeStatisticMock(Localization.of(context)!);
+
+        calculateAndRender(_date.month.toString(), _ledgerList);
+        _selectedChart = 1;
+      });
+      return null;
+    }, []);
 
     /// Month select Widget -> select month, set _date and calculate
     void onDatePressed() async {
-      int year = this._date.year;
+      int year = _date.year;
       int prevDate = year - 100;
       int lastDate = year + 10;
       // DateTime? pickDate = await showMonthPicker(
@@ -142,7 +137,7 @@ class _ContentState extends State<Content> {
     }
 
     Map<String, double> dataMap =
-        this._selectedChart == 1 ? this._dataMapIncome! : this._dataMapExpense!;
+        _selectedChart == 1 ? _dataMapIncome! : _dataMapExpense!;
 
     /// PieChart throws error when `_dataMap` is empty
     var chartWidget = dataMap.length > 0
@@ -209,16 +204,12 @@ class _ContentState extends State<Content> {
             ),
             ButtonGroup(
               onButtonOnePressed: () {
-                this.setState(() {
-                  this._selectedChart = 1;
-                });
+                _selectedChart = 1;
               },
               onButtonTwoPressed: () {
-                this.setState(() {
-                  this._selectedChart = 2;
-                });
+                _selectedChart = 2;
               },
-              selected: this._selectedChart,
+              selected: _selectedChart,
             ),
             chartWidget,
             bottomListWidget,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -1,6 +1,7 @@
 import 'package:wecount/mocks/home_statistic.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;
 import 'package:wecount/screens/home_statistic/functions.dart';
 
@@ -10,7 +11,6 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart';
 import 'package:flutter/material.dart';
 
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/widgets/home_header.dart' show renderHomeAppBar;
 import 'package:pie_chart/pie_chart.dart' show PieChart;
 // import 'package:month_picker_dialog/month_picker_dialog.dart';
@@ -43,8 +43,7 @@ class HomeStatistic extends StatelessWidget {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => General.instance
-                  .navigateScreenNamed(context, '/ledger_item_edit'),
+              onPressed: () => navigation.push(context, 'ledger_item_edit'),
               child: Icon(
                 Icons.add,
                 color: Colors.white,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -53,7 +53,7 @@ class HomeStatistic extends StatelessWidget {
           ),
         ],
       ),
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Container(
           child: Center(

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -6,7 +6,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/screens/sign_in.dart';
 import 'package:wecount/screens/sign_up.dart';
-import 'package:wecount/utils/logger.dart';
 import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
@@ -49,7 +48,6 @@ class Intro extends StatelessWidget {
         'updatedAt': FieldValue.serverTimestamp(),
         'deletedAt': null,
       });
-      print("here");
       _googleSignIn.signOut();
       Navigator.pushReplacementNamed(context, AuthSwitch.name);
     }

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -47,7 +47,7 @@ class Intro extends StatelessWidget {
         'deletedAt': null,
       });
       _googleSignIn.signOut();
-      Navigator.pushReplacementNamed(context, AppRoute.authSwitch.fullPath);
+      Navigator.pushReplacementNamed(context, AppRoute.authSwitch.path);
     }
   }
 
@@ -63,7 +63,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () => navigation.push(context, AppRoute.signIn.fullPath),
+        onPress: () => navigation.push(context, AppRoute.signIn.path),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -80,7 +80,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () => navigation.push(context, AppRoute.signUp.fullPath),
+          onPressed: () => navigation.push(context, AppRoute.signUp.path),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -65,7 +65,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () => navigation.push(context, SignIn.name),
+        onPress: () => navigation.push(context, 'sign-in'),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -82,7 +82,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () => navigation.push(context, SignUp.name),
+          onPressed: () => navigation.push(context, 'sign-up'),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/screens/sign_in.dart';
 import 'package:wecount/screens/sign_up.dart';
+import 'package:wecount/utils/logger.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/asset.dart' as Asset;
@@ -39,7 +40,6 @@ class Intro extends StatelessWidget {
       UserCredential auth =
           await FirebaseAuth.instance.signInWithCredential(credential);
       User user = auth.user!;
-
       await FirebaseFirestore.instance.collection('users').doc(user.uid).set({
         'email': user.email,
         'displayName': user.displayName,
@@ -49,7 +49,7 @@ class Intro extends StatelessWidget {
         'updatedAt': FieldValue.serverTimestamp(),
         'deletedAt': null,
       });
-
+      print("here");
       _googleSignIn.signOut();
       Navigator.pushReplacementNamed(context, AuthSwitch.name);
     }

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -7,10 +7,10 @@ import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/screens/sign_in.dart';
 import 'package:wecount/screens/sign_up.dart';
 import 'package:wecount/utils/logger.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/asset.dart' as Asset;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -23,7 +23,7 @@ class Intro extends StatelessWidget {
       scopes: ['email', 'https://www.googleapis.com/auth/contacts.readonly'],
     );
 
-    General.instance.showDialogSpinner(
+    navigation.showDialogSpinner(
       context,
       text: Localization.of(context)!.trans('SIGNING_IN_WITH_GOOGLE'),
     );
@@ -67,8 +67,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () =>
-            General.instance.navigateScreenNamed(context, SignIn.name),
+        onPress: () => navigation.push(context, SignIn.name),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -85,8 +84,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () =>
-              General.instance.navigateScreenNamed(context, SignUp.name),
+          onPressed: () => navigation.push(context, SignUp.name),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/intro.dart
+++ b/lib/screens/intro.dart
@@ -3,10 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:wecount/navigations/auth_switch.dart';
-import 'package:wecount/screens/sign_in.dart';
-import 'package:wecount/screens/sign_up.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/asset.dart' as Asset;
@@ -15,7 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class Intro extends StatelessWidget {
-  static const String name = '/intro';
+  const Intro({Key? key}) : super(key: key);
 
   Future<void> _googleLogin(BuildContext context) async {
     final GoogleSignIn _googleSignIn = GoogleSignIn(
@@ -49,7 +47,7 @@ class Intro extends StatelessWidget {
         'deletedAt': null,
       });
       _googleSignIn.signOut();
-      Navigator.pushReplacementNamed(context, AuthSwitch.name);
+      Navigator.pushReplacementNamed(context, AppRoute.authSwitch.fullPath);
     }
   }
 
@@ -65,7 +63,7 @@ class Intro extends StatelessWidget {
 
     Widget renderSignInBtn() {
       return Button(
-        onPress: () => navigation.push(context, 'sign-in'),
+        onPress: () => navigation.push(context, AppRoute.signIn.fullPath),
         margin: EdgeInsets.only(top: 198.0),
         textStyle: TextStyle(
           fontSize: 16.0,
@@ -82,7 +80,7 @@ class Intro extends StatelessWidget {
       return Container(
         margin: EdgeInsets.symmetric(vertical: 2.0),
         child: TextButton(
-          onPressed: () => navigation.push(context, 'sign-up'),
+          onPressed: () => navigation.push(context, AppRoute.signUp.fullPath),
           child: RichText(
             text: TextSpan(
               children: <TextSpan>[

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -41,6 +41,7 @@ class LedgerEdit extends HookWidget {
   Widget build(BuildContext context) {
     var _ledger = useState<Ledger?>(null);
     var _isLoading = useState<bool>(false);
+    var color = useState<ColorType?>(null);
 
     useEffect(() {
       if (ledger == null) {
@@ -72,6 +73,7 @@ class LedgerEdit extends HookWidget {
     }
 
     void _selectColor(ColorType item) {
+      color.value = item;
       _ledger.value!.color = item;
     }
 
@@ -342,7 +344,8 @@ class LedgerEdit extends HookWidget {
                               ? _localization.trans('DONE')!
                               : _localization.trans('UPDATE')!,
                           style: TextStyle(
-                            color: Asset.Colors.getColor(_ledger.value!.color),
+                            color: Colors.black,
+                            // color: Asset.Colors.getColor(_ledger.value!.color),
                             fontSize: 16.0,
                           ),
                         ),

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:wecount/screens/setting_currency.dart';
 import 'package:wecount/screens/members.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/member_horizontal_list.dart';
 import 'package:wecount/services/database.dart' show DatabaseService;
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
@@ -26,12 +27,10 @@ enum LedgerEditMode {
 }
 
 class LedgerEdit extends StatefulWidget {
-  static const String name = '/ledger-edit';
-
   final Ledger? ledger;
   final LedgerEditMode mode;
 
-  LedgerEdit({
+  const LedgerEdit({
     Key? key,
     this.ledger,
     this.mode = LedgerEditMode.ADD,
@@ -62,7 +61,7 @@ class _LedgerEditState extends State<LedgerEdit> {
   void _onPressCurrency() async {
     var _result = await navigation.navigate(
       context,
-      'setting-currency',
+      AppRoute.settingCurrency.fullPath,
       arguments: SettingCurrencyArguments(
         selectedCurrency: _ledger!.currency.currency,
       ),
@@ -305,7 +304,7 @@ class _LedgerEditState extends State<LedgerEdit> {
                       widget.ledger != null ? widget.ledger!.memberIds : [],
                   onSeeAllPressed: () => navigation.navigate(
                     context,
-                    'members',
+                    AppRoute.members.fullPath,
                     arguments: MembersArguments(ledger: widget.ledger),
                   ),
                 ),

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -61,7 +61,7 @@ class _LedgerEditState extends State<LedgerEdit> {
   void _onPressCurrency() async {
     var _result = await navigation.navigate(
       context,
-      AppRoute.settingCurrency.fullPath,
+      AppRoute.settingCurrency.path,
       arguments: SettingCurrencyArguments(
         selectedCurrency: _ledger!.currency.currency,
       ),
@@ -304,7 +304,7 @@ class _LedgerEditState extends State<LedgerEdit> {
                       widget.ledger != null ? widget.ledger!.memberIds : [],
                   onSeeAllPressed: () => navigation.navigate(
                     context,
-                    AppRoute.members.fullPath,
+                    AppRoute.members.path,
                     arguments: MembersArguments(ledger: widget.ledger),
                   ),
                 ),

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -2,10 +2,10 @@ import 'package:wecount/providers/current_ledger.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/screens/setting_currency.dart';
 import 'package:wecount/screens/members.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/member_horizontal_list.dart';
 import 'package:wecount/services/database.dart' show DatabaseService;
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/models/currency.dart';
@@ -13,13 +13,20 @@ import 'package:wecount/models/ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:provider/provider.dart';
 
+class LedgerEditArguments {
+  final Ledger? ledger;
+  final LedgerEditMode mode;
+
+  LedgerEditArguments({this.ledger, this.mode = LedgerEditMode.ADD});
+}
+
 enum LedgerEditMode {
   ADD,
   UPDATE,
 }
 
 class LedgerEdit extends StatefulWidget {
-  static const String name = '/ledger_edit';
+  static const String name = '/ledger-edit';
 
   final Ledger? ledger;
   final LedgerEditMode mode;
@@ -53,12 +60,11 @@ class _LedgerEditState extends State<LedgerEdit> {
   }
 
   void _onPressCurrency() async {
-    var _result = await General.instance.navigateScreen(
+    var _result = await navigation.navigate(
       context,
-      MaterialPageRoute(
-        builder: (BuildContext context) => SettingCurrency(
-          selectedCurrency: _ledger!.currency.currency,
-        ),
+      'setting-currency',
+      arguments: SettingCurrencyArguments(
+        selectedCurrency: _ledger!.currency.currency,
       ),
     );
 
@@ -120,7 +126,7 @@ class _LedgerEditState extends State<LedgerEdit> {
 
     var _localization = Localization.of(context)!;
 
-    General.instance.showSingleDialog(
+    navigation.showSingleDialog(
       context,
       title: Text(_localization.trans('ERROR')!),
       content: Text(_localization.trans('SHOULD_TRANSFER_OWNERSHIP')!),
@@ -297,13 +303,10 @@ class _LedgerEditState extends State<LedgerEdit> {
                   showAddBtn: true,
                   memberIds:
                       widget.ledger != null ? widget.ledger!.memberIds : [],
-                  onSeeAllPressed: () => General.instance.navigateScreen(
+                  onSeeAllPressed: () => navigation.navigate(
                     context,
-                    MaterialPageRoute(
-                      builder: (BuildContext context) => Members(
-                        ledger: widget.ledger,
-                      ),
-                    ),
+                    'members',
+                    arguments: MembersArguments(ledger: widget.ledger),
                   ),
                 ),
               ],

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -636,7 +636,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
           ),
         ],
       ),
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -655,7 +655,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
                   insets: EdgeInsets.symmetric(horizontal: 8),
                   // insets: EdgeInsets.fromLTRB(50.0, 0.0, 50.0, 40.0),
                 ),
-                indicatorColor: Theme.of(context).backgroundColor,
+                indicatorColor: Theme.of(context).colorScheme.background,
                 labelColor: Theme.of(context).textTheme.displayLarge!.color,
                 labelStyle: TextStyle(
                   fontSize: 20,

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -6,18 +6,18 @@ import 'package:wecount/models/ledger_item.dart' show LedgerItem;
 import 'package:wecount/models/photo.dart' show Photo;
 import 'package:wecount/screens/category_add.dart';
 import 'package:wecount/screens/location_view.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/category_list.dart';
 import 'package:wecount/widgets/gallery.dart' show Gallery;
 import 'package:wecount/widgets/header.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/db_helper.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/logger.dart';
 
 class LedgerItemEdit extends StatefulWidget {
-  static const String name = '/ledger_item_edit';
+  static const String name = '/ledger-item-edit';
 
   LedgerItemEdit({
     Key? key,
@@ -111,12 +111,8 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
     void onLocationPressed({
       CategoryType categoryType = CategoryType.CONSUME,
     }) async {
-      Map<String, dynamic>? result = await (General.instance.navigateScreen(
-        context,
-        MaterialPageRoute(
-          builder: (BuildContext context) => LocationView(),
-        ),
-      ));
+      Map<String, dynamic>? result =
+          await (navigation.navigate(context, 'location-view'));
 
       if (result == null) return;
 

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -5,8 +5,8 @@ import 'package:wecount/models/category.dart';
 import 'package:wecount/models/ledger_item.dart' show LedgerItem;
 import 'package:wecount/models/photo.dart' show Photo;
 import 'package:wecount/screens/category_add.dart';
-import 'package:wecount/screens/location_view.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/category_list.dart';
 import 'package:wecount/widgets/gallery.dart' show Gallery;
 import 'package:wecount/widgets/header.dart';
@@ -17,9 +17,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/logger.dart';
 
 class LedgerItemEdit extends StatefulWidget {
-  static const String name = '/ledger-item-edit';
-
-  LedgerItemEdit({
+  const LedgerItemEdit({
     Key? key,
     this.title = '',
   }) : super(key: key);
@@ -112,7 +110,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
       CategoryType categoryType = CategoryType.CONSUME,
     }) async {
       Map<String, dynamic>? result =
-          await (navigation.navigate(context, 'location-view'));
+          await (navigation.navigate(context, AppRoute.locationView.fullPath));
 
       if (result == null) return;
 

--- a/lib/screens/ledger_item_edit.dart
+++ b/lib/screens/ledger_item_edit.dart
@@ -110,7 +110,7 @@ class _LedgerItemEditState extends State<LedgerItemEdit>
       CategoryType categoryType = CategoryType.CONSUME,
     }) async {
       Map<String, dynamic>? result =
-          await (navigation.navigate(context, AppRoute.locationView.fullPath));
+          await (navigation.navigate(context, AppRoute.locationView.path));
 
       if (result == null) return;
 

--- a/lib/screens/ledger_view.dart
+++ b/lib/screens/ledger_view.dart
@@ -8,8 +8,14 @@ import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/types/color.dart';
 
+class LedgerViewArguments {
+  final Ledger? ledger;
+
+  LedgerViewArguments({this.ledger});
+}
+
 class LedgerView extends StatefulWidget {
-  static const String name = '/ledger_view';
+  static const String name = '/ledger-view';
 
   final Ledger? ledger;
   const LedgerView({

--- a/lib/screens/ledger_view.dart
+++ b/lib/screens/ledger_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/member_horizontal_list.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
@@ -14,38 +15,34 @@ class LedgerViewArguments {
   LedgerViewArguments({this.ledger});
 }
 
-class LedgerView extends StatefulWidget {
-  final Ledger? ledger;
+class LedgerView extends HookWidget {
   const LedgerView({
     Key? key,
     this.ledger,
   }) : super(key: key);
-
-  @override
-  _LedgerViewState createState() => _LedgerViewState(ledger);
-}
-
-class _LedgerViewState extends State<LedgerView> {
-  late Ledger _ledger;
-
-  _LedgerViewState(Ledger? ledger) {
-    if (ledger != null) {
-      _ledger = ledger;
-      return;
-    }
-    _ledger = Ledger(
-      title: 'ledger test',
-      currency: Currency(currency: '\￦', locale: 'KRW'),
-      color: ColorType.DUSK,
-    );
-  }
+  final Ledger? ledger;
 
   @override
   Widget build(BuildContext context) {
+    var _ledger = useState<Ledger?>(null);
+
+    useEffect(() {
+      if (ledger != null) {
+        _ledger.value = ledger;
+        return;
+      }
+      _ledger.value = Ledger(
+        title: 'ledger test',
+        currency: Currency(currency: '\￦', locale: 'KRW'),
+        color: ColorType.DUSK,
+      );
+      return null;
+    }, []);
+
     var _localization = Localization.of(context)!;
 
     return Scaffold(
-      backgroundColor: Asset.Colors.getColor(_ledger.color),
+      backgroundColor: Asset.Colors.getColor(_ledger.value!.color),
       appBar: renderHeaderBack(
         context: context,
         iconColor: Colors.white,
@@ -60,9 +57,9 @@ class _LedgerViewState extends State<LedgerView> {
                 enabled: false,
                 maxLines: 2,
                 onChanged: (String txt) {
-                  _ledger.title = txt;
+                  _ledger.value!.title = txt;
                 },
-                controller: TextEditingController(text: _ledger.title),
+                controller: TextEditingController(text: _ledger.value!.title),
                 decoration: InputDecoration(
                   hintMaxLines: 2,
                   border: InputBorder.none,
@@ -84,9 +81,10 @@ class _LedgerViewState extends State<LedgerView> {
               child: TextField(
                 enabled: false,
                 maxLines: 8,
-                controller: TextEditingController(text: _ledger.description),
+                controller:
+                    TextEditingController(text: _ledger.value!.description),
                 onChanged: (String txt) {
-                  _ledger.description = txt;
+                  _ledger.value!.description = txt;
                 },
                 textAlignVertical: TextAlignVertical.top,
                 decoration: InputDecoration(
@@ -123,7 +121,7 @@ class _LedgerViewState extends State<LedgerView> {
                     Row(
                       children: <Widget>[
                         Text(
-                          '${_ledger.currency.locale} | ${_ledger.currency.currency}',
+                          '${_ledger.value!.currency.locale} | ${_ledger.value!.currency.currency}',
                           style: TextStyle(
                             color: Colors.white,
                             fontSize: 16,
@@ -170,7 +168,7 @@ class _LedgerViewState extends State<LedgerView> {
                         itemExtent: 32,
                         itemBuilder: (context, index) {
                           final item = colorItems[index];
-                          bool selected = item == _ledger.color;
+                          bool selected = item == _ledger.value!.color;
                           return ColorItem(
                             color: item,
                             selected: selected,

--- a/lib/screens/ledger_view.dart
+++ b/lib/screens/ledger_view.dart
@@ -15,8 +15,6 @@ class LedgerViewArguments {
 }
 
 class LedgerView extends StatefulWidget {
-  static const String name = '/ledger-view';
-
   final Ledger? ledger;
   const LedgerView({
     Key? key,

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -55,7 +55,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onAddLedgerPressed() {
-      navigation.push(context, '/ledger_edit');
+      navigation.push(context, '/ledger-edit');
     }
 
     return Scaffold(

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -60,7 +60,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -31,11 +31,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      navigation.push(context, Setting.name);
+      navigation.push(context, 'setting');
     }
 
     void onProfilePressed() {
-      navigation.push(context, ProfileMy.name);
+      navigation.push(context, 'profile-my');
     }
 
     void onLedgerPressed(Ledger item) {

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -83,7 +83,6 @@ class Ledgers extends HookWidget {
                   if (!snapshot.hasData) return Container();
 
                   var profile = snapshot.data;
-
                   return ProfileListItem(
                     email: profile.email ?? '',
                     displayName: profile.displayName ?? '',

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -1,11 +1,10 @@
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:wecount/screens/profile_my.dart';
-import 'package:wecount/screens/setting.dart';
 
 import 'package:wecount/services/database.dart' show DatabaseService;
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/screens/ledger_edit.dart';
 import 'package:wecount/screens/ledger_view.dart';
@@ -17,9 +16,7 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:provider/provider.dart' show Provider;
 
 class Ledgers extends StatefulWidget {
-  static const String name = '/ledgers';
-
-  Ledgers({Key? key}) : super(key: key);
+  const Ledgers({Key? key}) : super(key: key);
 
   @override
   _LedgersState createState() => _LedgersState();
@@ -31,11 +28,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      navigation.push(context, 'setting');
+      navigation.push(context, AppRoute.setting.fullPath);
     }
 
     void onProfilePressed() {
-      navigation.push(context, 'profile-my');
+      navigation.push(context, AppRoute.profileMy.fullPath);
     }
 
     void onLedgerPressed(Ledger item) {
@@ -47,7 +44,9 @@ class _LedgersState extends State<Ledgers> {
     void onLedgerMorePressed(Ledger item) {
       navigation.navigate(
         context,
-        item.ownerId != user.uid ? 'ledger-view' : 'ledger-edit',
+        item.ownerId != user.uid
+            ? AppRoute.ledgerView.fullPath
+            : AppRoute.ledgerEdit.fullPath,
         arguments: item.ownerId != user.uid
             ? LedgerViewArguments(ledger: item)
             : LedgerEditArguments(ledger: item, mode: LedgerEditMode.UPDATE),
@@ -55,7 +54,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onAddLedgerPressed() {
-      navigation.push(context, '/ledger-edit');
+      navigation.push(context, AppRoute.ledgerEdit.fullPath);
     }
 
     return Scaffold(

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -15,14 +16,9 @@ import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:provider/provider.dart' show Provider;
 
-class Ledgers extends StatefulWidget {
+class Ledgers extends HookWidget {
   const Ledgers({Key? key}) : super(key: key);
 
-  @override
-  _LedgersState createState() => _LedgersState();
-}
-
-class _LedgersState extends State<Ledgers> {
   @override
   Widget build(BuildContext context) {
     User? user = FirebaseAuth.instance.currentUser!;

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -5,6 +5,7 @@ import 'package:wecount/screens/profile_my.dart';
 import 'package:wecount/screens/setting.dart';
 
 import 'package:wecount/services/database.dart' show DatabaseService;
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/screens/ledger_edit.dart';
 import 'package:wecount/screens/ledger_view.dart';
@@ -13,7 +14,6 @@ import 'package:wecount/widgets/ledger_list_item.dart' show LedgerListItem;
 import 'package:wecount/models/ledger.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
-import 'package:wecount/utils/general.dart';
 import 'package:provider/provider.dart' show Provider;
 
 class Ledgers extends StatefulWidget {
@@ -31,11 +31,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      General.instance.navigateScreenNamed(context, Setting.name);
+      navigation.push(context, Setting.name);
     }
 
     void onProfilePressed() {
-      General.instance.navigateScreenNamed(context, ProfileMy.name);
+      navigation.push(context, ProfileMy.name);
     }
 
     void onLedgerPressed(Ledger item) {
@@ -45,18 +45,17 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onLedgerMorePressed(Ledger item) {
-      General.instance.navigateScreen(
+      navigation.navigate(
         context,
-        MaterialPageRoute(
-          builder: (BuildContext context) => item.ownerId != user.uid
-              ? LedgerView(ledger: item)
-              : LedgerEdit(ledger: item, mode: LedgerEditMode.UPDATE),
-        ),
+        item.ownerId != user.uid ? 'ledger-view' : 'ledger-edit',
+        arguments: item.ownerId != user.uid
+            ? LedgerViewArguments(ledger: item)
+            : LedgerEditArguments(ledger: item, mode: LedgerEditMode.UPDATE),
       );
     }
 
     void onAddLedgerPressed() {
-      General.instance.navigateScreenNamed(context, '/ledger_edit');
+      navigation.push(context, '/ledger_edit');
     }
 
     return Scaffold(

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -28,11 +28,11 @@ class _LedgersState extends State<Ledgers> {
     User? user = FirebaseAuth.instance.currentUser!;
     var _localization = Localization.of(context)!;
     void onSettingPressed() {
-      navigation.push(context, AppRoute.setting.fullPath);
+      navigation.push(context, AppRoute.setting.path);
     }
 
     void onProfilePressed() {
-      navigation.push(context, AppRoute.profileMy.fullPath);
+      navigation.push(context, AppRoute.profileMy.path);
     }
 
     void onLedgerPressed(Ledger item) {
@@ -45,8 +45,8 @@ class _LedgersState extends State<Ledgers> {
       navigation.navigate(
         context,
         item.ownerId != user.uid
-            ? AppRoute.ledgerView.fullPath
-            : AppRoute.ledgerEdit.fullPath,
+            ? AppRoute.ledgerView.path
+            : AppRoute.ledgerEdit.path,
         arguments: item.ownerId != user.uid
             ? LedgerViewArguments(ledger: item)
             : LedgerEditArguments(ledger: item, mode: LedgerEditMode.UPDATE),
@@ -54,7 +54,7 @@ class _LedgersState extends State<Ledgers> {
     }
 
     void onAddLedgerPressed() {
-      navigation.push(context, AppRoute.ledgerEdit.fullPath);
+      navigation.push(context, AppRoute.ledgerEdit.path);
     }
 
     return Scaffold(

--- a/lib/screens/line_graph.dart
+++ b/lib/screens/line_graph.dart
@@ -77,7 +77,7 @@ class _LineGraphState extends State<LineGraph> {
     /// Render
     return Scaffold(
       // resizeToAvoidBottomPadding: false,
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/line_graph.dart
+++ b/lib/screens/line_graph.dart
@@ -8,6 +8,14 @@ import '../widgets/header.dart' show renderHeaderBack;
 
 import 'package:intl/intl.dart' show DateFormat, NumberFormat;
 
+class LineGraphArguments {
+  final String title;
+  final String year;
+  final double? price;
+
+  LineGraphArguments(this.title, this.year, this.price);
+}
+
 double getPriceSum(List<LedgerItem> items) {
   double sum = 0;
   items.forEach((item) {
@@ -18,15 +26,13 @@ double getPriceSum(List<LedgerItem> items) {
 
 /// main
 class LineGraph extends StatefulWidget {
-  static const String name = '/line_graph';
+  static const String name = '/line-graph';
 
-  LineGraph({
-    Key? key,
-    this.title = '',
-    this.year = '2019',
-  }) : super(key: key);
+  LineGraph({Key? key, this.title = '', this.year = '2019', this.price = 0.0})
+      : super(key: key);
   final String title;
   final String year;
+  final double price;
 
   @override
   _LineGraphState createState() => _LineGraphState();
@@ -89,7 +95,8 @@ class _LineGraphState extends State<LineGraph> {
           children: <Widget>[
             headerAlign(
               child: Text(
-                _localization.trans('CAFE')!,
+                '${widget.title}',
+                // _localization.trans('CAFE')!,
                 style: TextStyle(
                   fontSize: 30,
                   color: Theme.of(context).textTheme.displayLarge!.color,
@@ -108,7 +115,7 @@ class _LineGraphState extends State<LineGraph> {
                 : BottomListTitle(
                     date: DateFormat('y')
                         .format(DateTime(int.parse(widget.year))),
-                    price: this._priceSum),
+                    price: widget.price),
             Divider(
               color: Colors.grey,
               height: 1,

--- a/lib/screens/line_graph.dart
+++ b/lib/screens/line_graph.dart
@@ -26,9 +26,8 @@ double getPriceSum(List<LedgerItem> items) {
 
 /// main
 class LineGraph extends StatefulWidget {
-  static const String name = '/line-graph';
-
-  LineGraph({Key? key, this.title = '', this.year = '2019', this.price = 0.0})
+  const LineGraph(
+      {Key? key, this.title = '', this.year = '2019', this.price = 0.0})
       : super(key: key);
   final String title;
   final String year;

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -8,7 +8,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
 class LocationView extends StatefulWidget {
-  static const name = '/location-view';
+  const LocationView({Key? key}) : super(key: key);
 
   @override
   _LocationViewState createState() => _LocationViewState();

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:geocoding/geocoding.dart'
     show Placemark, placemarkFromCoordinates;
 import 'package:wecount/widgets/header.dart';
@@ -7,108 +8,100 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
-class LocationView extends StatefulWidget {
+class LocationView extends HookWidget {
   const LocationView({Key? key}) : super(key: key);
 
   @override
-  _LocationViewState createState() => _LocationViewState();
-}
-
-class _LocationViewState extends State<LocationView> {
-  late GoogleMapController mapController;
-  LatLng? _center;
-  Map<MarkerId, Marker> markers = <MarkerId, Marker>{};
-  late Set<Marker> _markerSet;
-  late String _countryCode;
-
-  @override
-  void initState() {
-    _countryCode = WidgetsBinding.instance.window.locale.countryCode!;
-    super.initState();
-    getCurrentLocation();
-  }
-
-  /// Open up google place search screen. The `_countryCode` is used to query google places.
-  ///
-  /// Get `lat` and `lng` from the places search.
-  /// Move camera and set markers when there is a result.
-  ///
-  void getPlace() async {
-    var location = await GooglePlaceService.instance.showGooglePlaceSearch(
-      context,
-      country: _countryCode,
-    );
-
-    if (location['lat'] != null && location['lng'] != null) {
-      var latLng = LatLng(location['lat'], location['lng']);
-      _setMarker(latLng);
-
-      setState(() => _center = latLng);
-
-      CameraUpdate cameraUpdate = CameraUpdate.newLatLng(latLng);
-      mapController.moveCamera(cameraUpdate);
-    }
-  }
-
-  /// Get current location with `location` plugin.
-  ///
-  /// This will request permission in android when it's not granted.
-  /// When permission is granted, it will get current location by calling `getLocation`,
-  /// and set markers when result is achieved.
-  ///
-  /// It also fetches current `countryCode` to be used when searching google places.
-  ///
-  void getCurrentLocation() async {
-    var currentLocation;
-    var error;
-
-    var location = Location();
-
-    try {
-      currentLocation = await location.getLocation();
-    } catch (e) {
-      // if (e.currency == 'PERMISSION_DENIED') {
-      //   error = 'Permission denied';
-      // }
-      currentLocation = null;
-    }
-
-    if (error == null) {
-      final LatLng latLng =
-          LatLng(currentLocation.latitude, currentLocation.longitude);
-      _setMarker(latLng);
-
-      setState(() => _center = latLng);
-      return;
-    }
-
-    setState(() => _center = LatLng(0, 0));
-  }
-
-  void _setMarker(LatLng latLng) {
-    MarkerId markerId = MarkerId('myMarker');
-
-    // creating a new MARKER
-    final Marker marker = Marker(
-      markerId: markerId,
-      position: latLng,
-    );
-
-    markers[markerId] = marker;
-
-    setState(() {
-      _markerSet = Set<Marker>.of(markers.values);
-    });
-  }
-
-  void _onMapCreated(GoogleMapController controller) {
-    mapController = controller;
-  }
-
-  void _onCameraMoved(CameraPosition pos) => _setMarker(pos.target);
-
-  @override
   Widget build(BuildContext context) {
+    late GoogleMapController mapController;
+    var _center = useState<LatLng?>(null);
+    var _markerSet = useState<Set<Marker>>({});
+    Map<MarkerId, Marker> markers = <MarkerId, Marker>{};
+    late String _countryCode;
+
+    void _setMarker(LatLng latLng) {
+      MarkerId markerId = MarkerId('myMarker');
+
+      // creating a new MARKER
+      final Marker marker = Marker(
+        markerId: markerId,
+        position: latLng,
+      );
+
+      markers[markerId] = marker;
+
+      _markerSet.value = Set<Marker>.of(markers.values);
+    }
+
+    /// Get current location with `location` plugin.
+    ///
+    /// This will request permission in android when it's not granted.
+    /// When permission is granted, it will get current location by calling `getLocation`,
+    /// and set markers when result is achieved.
+    ///
+    /// It also fetches current `countryCode` to be used when searching google places.
+    ///
+    void getCurrentLocation() async {
+      var currentLocation;
+      var error;
+
+      var location = Location();
+
+      try {
+        currentLocation = await location.getLocation();
+      } catch (e) {
+        // if (e.currency == 'PERMISSION_DENIED') {
+        //   error = 'Permission denied';
+        // }
+        currentLocation = null;
+      }
+
+      if (error == null) {
+        final LatLng latLng =
+            LatLng(currentLocation.latitude, currentLocation.longitude);
+        _setMarker(latLng);
+
+        _center.value = latLng;
+        return;
+      }
+
+      _center.value = LatLng(0, 0);
+    }
+
+    useEffect(() {
+      _countryCode = WidgetsBinding.instance.window.locale.countryCode!;
+      getCurrentLocation();
+      return null;
+    }, []);
+
+    /// Open up google place search screen. The `_countryCode` is used to query google places.
+    ///
+    /// Get `lat` and `lng` from the places search.
+    /// Move camera and set markers when there is a result.
+    ///
+    void getPlace() async {
+      var location = await GooglePlaceService.instance.showGooglePlaceSearch(
+        context,
+        country: _countryCode,
+      );
+
+      if (location['lat'] != null && location['lng'] != null) {
+        var latLng = LatLng(location['lat'], location['lng']);
+        _setMarker(latLng);
+
+        _center.value = latLng;
+
+        CameraUpdate cameraUpdate = CameraUpdate.newLatLng(latLng);
+        mapController.moveCamera(cameraUpdate);
+      }
+    }
+
+    void _onMapCreated(GoogleMapController controller) {
+      mapController = controller;
+    }
+
+    void _onCameraMoved(CameraPosition pos) => _setMarker(pos.target);
+
     return _center == null
         ? const LoadingIndicator()
         : Scaffold(
@@ -142,8 +135,8 @@ class _LocationViewState extends State<LocationView> {
                     onPressed: () async {
                       List<Placemark> addresses =
                           await placemarkFromCoordinates(
-                        _center!.latitude,
-                        _center!.longitude,
+                        _center.value!.latitude,
+                        _center.value!.longitude,
                       );
                       Map<String, dynamic> result = Map();
                       result['address'] = addresses.first.street;
@@ -162,10 +155,10 @@ class _LocationViewState extends State<LocationView> {
             body: GoogleMap(
               onMapCreated: _onMapCreated,
               initialCameraPosition: CameraPosition(
-                target: _center!,
+                target: _center.value!,
                 zoom: 11.0,
               ),
-              markers: _markerSet,
+              markers: _markerSet.value,
               onCameraMove: _onCameraMoved,
             ),
           );

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -8,6 +8,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
 class LocationView extends StatefulWidget {
+  static const name = '/location-view';
+
   @override
   _LocationViewState createState() => _LocationViewState();
 }

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -110,7 +110,7 @@ class _LocationViewState extends State<LocationView> {
     return _center == null
         ? const LoadingIndicator()
         : Scaffold(
-            backgroundColor: Theme.of(context).backgroundColor,
+            backgroundColor: Theme.of(context).colorScheme.background,
             appBar: renderHeaderClose(
               context: context,
               brightness: Theme.of(context).brightness,

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
 import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
@@ -10,123 +11,179 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:local_auth/local_auth.dart';
 
-class LockAuth extends StatefulWidget {
+class LockAuth extends HookWidget {
   const LockAuth({Key? key}) : super(key: key);
 
   @override
-  _LockAuthState createState() => _LockAuthState();
-}
-
-class _LockAuthState extends State<LockAuth> {
-  late Size _screenSize;
-  int? _currentDigit;
-
-  int? _firstDigit;
-  int? _secondDigit;
-  int? _thirdDigit;
-  int? _fourthDigit;
-
-  Localization? _localization;
-
-  String? _pin = '';
-  String _inputPin = '';
-
-  /// LocalAuthentication - Fingerprint
-  final LocalAuthentication _localAuthentication = LocalAuthentication();
-  bool _hasFingerPrintSupport = false;
-
-  Future<void> checkFingerprintSupport() async {
-    bool isBiometricSupport = false;
-    List<BiometricType> availableBiometricType = [];
-
-    try {
-      isBiometricSupport = await _localAuthentication.canCheckBiometrics;
-      if (!isBiometricSupport) return;
-    } catch (e) {
-      print(e);
-    }
-    if (!mounted) return;
-
-    try {
-      availableBiometricType =
-          await _localAuthentication.getAvailableBiometrics();
-    } catch (e) {
-      print(e);
-    }
-    if (!mounted) return;
-
-    setState(() {
-      if (availableBiometricType.contains(BiometricType.fingerprint)) {
-        _hasFingerPrintSupport = true;
-      } else {
-        _hasFingerPrintSupport = false;
-      }
-    });
-  }
-
-  Future<void> _authenticateMe() async {
-    // 8. this method opens a dialog for fingerprint authentication.
-    //    we do not need to create a dialog nut it pop sup from device natively.
-    bool authenticated = false;
-    try {
-      authenticated = await _localAuthentication.authenticate(
-        localizedReason:
-            _localization!.trans('FINGERPRINT_LOGIN')!, // message for dialog
-        options: AuthenticationOptions(
-          useErrorDialogs: true,
-          stickyAuth: true,
-        ),
-      );
-    } catch (e) {
-      print(e);
-    }
-    if (!mounted) return;
-
-    if (authenticated) {
-      Navigator.pop(context, false);
-    } else {
-      return;
-    }
-  }
-
-  readLockPinFromSF() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-
-    if (prefs.containsKey('LOCK_PIN')) {
-      _pin = prefs.getString('LOCK_PIN');
-      print(_pin);
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-    ]);
-
-    checkFingerprintSupport();
-    readLockPinFromSF();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-      DeviceOrientation.portraitDown,
-      DeviceOrientation.portraitUp,
-    ]);
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final mounted = useIsMounted();
+    late Size _screenSize;
+    var _currentDigit = useState<int?>(0);
+
+    var _firstDigit = useState<int?>(null);
+    var _secondDigit = useState<int?>(null);
+    var _thirdDigit = useState<int?>(null);
+    var _fourthDigit = useState<int?>(null);
+
+    Localization? _localization;
+    String? _pin = '';
+    String _inputPin = '';
+
+    void _setCurrentDigit(int i) {
+      _currentDigit.value = i;
+      if (_firstDigit.value == null) {
+        _firstDigit.value = _currentDigit.value;
+      } else if (_secondDigit.value == null) {
+        _secondDigit.value = _currentDigit.value;
+      } else if (_thirdDigit.value == null) {
+        _thirdDigit.value = _currentDigit.value;
+      } else if (_fourthDigit.value == null) {
+        _fourthDigit.value = _currentDigit.value;
+
+        _inputPin = _firstDigit.toString() +
+            _secondDigit.toString() +
+            _thirdDigit.toString() +
+            _fourthDigit.toString();
+
+        print('INPUT PIN is $_inputPin');
+      }
+
+      if (_inputPin.length == 4) {
+        if (_inputPin == _pin) {
+          Navigator.pop(context, false);
+        } else {
+          Fluttertoast.showToast(
+            msg: _localization!.trans('PIN_MISMATCH')!,
+            toastLength: Toast.LENGTH_SHORT,
+            gravity: ToastGravity.CENTER,
+            timeInSecForIosWeb: 1,
+            fontSize: 16.0,
+          );
+
+          _inputPin = '';
+        }
+      }
+    }
+
+    /// LocalAuthentication - Fingerprint
+    final LocalAuthentication _localAuthentication = LocalAuthentication();
+    var _hasFingerPrintSupport = useState<bool>(false);
+
+    Future<void> checkFingerprintSupport() async {
+      bool isBiometricSupport = false;
+      List<BiometricType> availableBiometricType = [];
+
+      try {
+        isBiometricSupport = await _localAuthentication.canCheckBiometrics;
+        if (!isBiometricSupport) return;
+      } catch (e) {
+        print(e);
+      }
+      if (!mounted()) return;
+
+      try {
+        availableBiometricType =
+            await _localAuthentication.getAvailableBiometrics();
+      } catch (e) {
+        print(e);
+      }
+      if (!mounted()) return;
+
+      if (availableBiometricType.contains(BiometricType.fingerprint)) {
+        _hasFingerPrintSupport.value = true;
+      } else {
+        _hasFingerPrintSupport.value = false;
+      }
+    }
+
+    Future<void> _authenticateMe() async {
+      // 8. this method opens a dialog for fingerprint authentication.
+      //    we do not need to create a dialog nut it pop sup from device natively.
+      bool authenticated = false;
+      try {
+        authenticated = await _localAuthentication.authenticate(
+          localizedReason:
+              _localization!.trans('FINGERPRINT_LOGIN')!, // message for dialog
+          options: AuthenticationOptions(
+            useErrorDialogs: true,
+            stickyAuth: true,
+          ),
+        );
+      } catch (e) {
+        print(e);
+      }
+      if (!mounted()) return;
+
+      if (authenticated) {
+        Navigator.pop(context, false);
+      } else {
+        return;
+      }
+    }
+
+    readLockPinFromSF() async {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+
+      if (prefs.containsKey('LOCK_PIN')) {
+        _pin = prefs.getString('LOCK_PIN');
+        print(_pin);
+      }
+    }
+
+    useEffect(() {
+      SystemChrome.setPreferredOrientations([
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ]);
+
+      checkFingerprintSupport();
+      readLockPinFromSF();
+      return () {
+        SystemChrome.setPreferredOrientations([
+          DeviceOrientation.landscapeLeft,
+          DeviceOrientation.landscapeRight,
+          DeviceOrientation.portraitDown,
+          DeviceOrientation.portraitUp,
+        ]);
+      };
+    }, []);
+
     _localization = Localization.of(context);
     _screenSize = MediaQuery.of(context).size;
+
+    void _deleteCurrentDigit() {
+      if (_fourthDigit.value != null) {
+        _fourthDigit.value = null;
+      } else if (_thirdDigit.value != null) {
+        _thirdDigit.value = null;
+      } else if (_secondDigit.value != null) {
+        _secondDigit.value = null;
+      } else if (_firstDigit.value != null) {
+        _firstDigit.value = null;
+      }
+    }
+
+    Widget _pinTextField(int? digit) {
+      return Container(
+          width: 50,
+          height: 45,
+          alignment: Alignment.center,
+          child: Text(
+            digit != null ? digit.toString() : "",
+            style: TextStyle(
+              fontSize: 30,
+              color: Theme.of(context).textTheme.displayLarge!.color,
+            ),
+          ),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: Theme.of(context).textTheme.displayLarge!.color!,
+                width: 2,
+              ),
+            ),
+          ));
+    }
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -154,10 +211,10 @@ class _LockAuthState extends State<LockAuth> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  _pinTextField(_firstDigit),
-                  _pinTextField(_secondDigit),
-                  _pinTextField(_thirdDigit),
-                  _pinTextField(_fourthDigit),
+                  _pinTextField(_firstDigit.value),
+                  _pinTextField(_secondDigit.value),
+                  _pinTextField(_thirdDigit.value),
+                  _pinTextField(_fourthDigit.value),
                 ],
               ),
             ),
@@ -167,7 +224,7 @@ class _LockAuthState extends State<LockAuth> {
                 style: TextStyle(
                     color: Theme.of(context).textTheme.displayMedium!.color),
               ),
-              onPressed: _hasFingerPrintSupport ? _authenticateMe : null,
+              onPressed: _hasFingerPrintSupport.value ? _authenticateMe : null,
               // shape: RoundedRectangleBorder(
               //   borderRadius: BorderRadius.circular(30),
               // ),
@@ -184,79 +241,5 @@ class _LockAuthState extends State<LockAuth> {
         ),
       ),
     );
-  }
-
-  void _setCurrentDigit(int i) {
-    setState(() {
-      _currentDigit = i;
-      if (_firstDigit == null) {
-        _firstDigit = _currentDigit;
-      } else if (_secondDigit == null) {
-        _secondDigit = _currentDigit;
-      } else if (_thirdDigit == null) {
-        _thirdDigit = _currentDigit;
-      } else if (_fourthDigit == null) {
-        _fourthDigit = _currentDigit;
-
-        _inputPin = _firstDigit.toString() +
-            _secondDigit.toString() +
-            _thirdDigit.toString() +
-            _fourthDigit.toString();
-
-        print('INPUT PIN is $_inputPin');
-      }
-    });
-
-    if (_inputPin.length == 4) {
-      if (_inputPin == _pin) {
-        Navigator.pop(context, false);
-      } else {
-        Fluttertoast.showToast(
-          msg: _localization!.trans('PIN_MISMATCH')!,
-          toastLength: Toast.LENGTH_SHORT,
-          gravity: ToastGravity.CENTER,
-          timeInSecForIosWeb: 1,
-          fontSize: 16.0,
-        );
-
-        _inputPin = '';
-      }
-    }
-  }
-
-  void _deleteCurrentDigit() {
-    setState(() {
-      if (_fourthDigit != null) {
-        _fourthDigit = null;
-      } else if (_thirdDigit != null) {
-        _thirdDigit = null;
-      } else if (_secondDigit != null) {
-        _secondDigit = null;
-      } else if (_firstDigit != null) {
-        _firstDigit = null;
-      }
-    });
-  }
-
-  Widget _pinTextField(int? digit) {
-    return Container(
-        width: 50,
-        height: 45,
-        alignment: Alignment.center,
-        child: Text(
-          digit != null ? digit.toString() : "",
-          style: TextStyle(
-            fontSize: 30,
-            color: Theme.of(context).textTheme.displayLarge!.color,
-          ),
-        ),
-        decoration: BoxDecoration(
-          border: Border(
-            bottom: BorderSide(
-              color: Theme.of(context).textTheme.displayLarge!.color!,
-              width: 2,
-            ),
-          ),
-        ));
   }
 }

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -11,7 +11,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:local_auth/local_auth.dart';
 
 class LockAuth extends StatefulWidget {
-  static const String name = '/lock_auth';
+  static const String name = '/lock-auth';
 
   @override
   _LockAuthState createState() => _LockAuthState();

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -11,7 +11,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:local_auth/local_auth.dart';
 
 class LockAuth extends StatefulWidget {
-  static const String name = '/lock-auth';
+  const LockAuth({Key? key}) : super(key: key);
 
   @override
   _LockAuthState createState() => _LockAuthState();

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -129,7 +129,7 @@ class _LockAuthState extends State<LockAuth> {
     _screenSize = MediaQuery.of(context).size;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         context: context,
         iconColor: Theme.of(context).iconTheme.color,

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -7,7 +7,7 @@ import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
 import 'package:wecount/utils/localization.dart' show Localization;
 
 class LockRegister extends StatefulWidget {
-  static const String name = '/lock-register';
+  const LockRegister({Key? key}) : super(key: key);
 
   @override
   _LockRegisterState createState() => _LockRegisterState();

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -7,7 +7,7 @@ import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
 import 'package:wecount/utils/localization.dart' show Localization;
 
 class LockRegister extends StatefulWidget {
-  static const String name = '/lock_register';
+  static const String name = '/lock-register';
 
   @override
   _LockRegisterState createState() => _LockRegisterState();

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -1,84 +1,128 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
 import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
 import 'package:wecount/utils/localization.dart' show Localization;
 
-class LockRegister extends StatefulWidget {
+class LockRegister extends HookWidget {
   const LockRegister({Key? key}) : super(key: key);
 
   @override
-  _LockRegisterState createState() => _LockRegisterState();
-}
-
-class _LockRegisterState extends State<LockRegister> {
-  late Size _screenSize;
-
-  int? _currentDigit;
-
-  int? _firstDigit;
-  int? _secondDigit;
-  int? _thirdDigit;
-  int? _fourthDigit;
-
-  String? _pin = '';
-
-  readLockPinFromSF() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-
-    if (prefs.containsKey('LOCK_PIN')) {
-      _pin = prefs.getString('LOCK_PIN');
-      print(_pin);
-    }
-  }
-
-  addLockPinToSF() async {
-    if (_pin!.length != 4) {
-      return;
-    } else {
-      SharedPreferences prefs = await SharedPreferences.getInstance();
-      prefs.setString('LOCK_PIN', _pin!);
-      Navigator.of(context).pop();
-      print(_pin);
-    }
-  }
-
-  resetLockPinToSF() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    prefs.remove('LOCK_PIN');
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    resetLockPinToSF();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-    ]);
-
-    readLockPinFromSF();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-      DeviceOrientation.portraitDown,
-      DeviceOrientation.portraitUp,
-    ]);
-  }
-
-  @override
   Widget build(BuildContext context) {
+    late Size _screenSize;
+
+    var _currentDigit = useState<int?>(null);
+
+    var _firstDigit = useState<int?>(null);
+    var _secondDigit = useState<int?>(null);
+    var _thirdDigit = useState<int?>(null);
+    var _fourthDigit = useState<int?>(null);
+
+    String? _pin = '';
+
+    readLockPinFromSF() async {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+
+      if (prefs.containsKey('LOCK_PIN')) {
+        _pin = prefs.getString('LOCK_PIN');
+        print(_pin);
+      }
+    }
+
+    addLockPinToSF() async {
+      if (_pin!.length != 4) {
+        return;
+      } else {
+        SharedPreferences prefs = await SharedPreferences.getInstance();
+        prefs.setString('LOCK_PIN', _pin!);
+        Navigator.of(context).pop();
+        print(_pin);
+      }
+    }
+
+    resetLockPinToSF() async {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      prefs.remove('LOCK_PIN');
+    }
+
+    useEffect(() {
+      resetLockPinToSF();
+
+      SystemChrome.setPreferredOrientations([
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ]);
+
+      readLockPinFromSF();
+      return () {
+        SystemChrome.setPreferredOrientations([
+          DeviceOrientation.landscapeLeft,
+          DeviceOrientation.landscapeRight,
+          DeviceOrientation.portraitDown,
+          DeviceOrientation.portraitUp,
+        ]);
+      };
+    }, []);
+
     var _localization = Localization.of(context)!;
     _screenSize = MediaQuery.of(context).size;
+
+    void _setCurrentDigit(int i) {
+      _currentDigit.value = i;
+      if (_firstDigit.value == null) {
+        _firstDigit.value = _currentDigit.value;
+      } else if (_secondDigit.value == null) {
+        _secondDigit.value = _currentDigit.value;
+      } else if (_thirdDigit.value == null) {
+        _thirdDigit.value = _currentDigit.value;
+      } else if (_fourthDigit.value == null) {
+        _fourthDigit.value = _currentDigit.value;
+
+        _pin = _firstDigit.toString() +
+            _secondDigit.toString() +
+            _thirdDigit.toString() +
+            _fourthDigit.toString();
+
+        print(_pin);
+      }
+    }
+
+    void _deleteCurrentDigit() {
+      if (_fourthDigit.value != null) {
+        _fourthDigit.value = null;
+      } else if (_thirdDigit.value != null) {
+        _thirdDigit.value = null;
+      } else if (_secondDigit.value != null) {
+        _secondDigit.value = null;
+      } else if (_firstDigit.value != null) {
+        _firstDigit.value = null;
+      }
+    }
+
+    Widget _pinTextField(int? digit) {
+      return Container(
+          width: 50,
+          height: 45,
+          alignment: Alignment.center,
+          child: Text(
+            digit != null ? digit.toString() : "",
+            style: TextStyle(
+              fontSize: 30,
+              color: Theme.of(context).textTheme.displayLarge!.color,
+            ),
+          ),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: Theme.of(context).textTheme.displayLarge!.color!,
+                width: 2,
+              ),
+            ),
+          ));
+    }
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -116,10 +160,10 @@ class _LockRegisterState extends State<LockRegister> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  _pinTextField(_firstDigit),
-                  _pinTextField(_secondDigit),
-                  _pinTextField(_thirdDigit),
-                  _pinTextField(_fourthDigit),
+                  _pinTextField(_firstDigit.value),
+                  _pinTextField(_secondDigit.value),
+                  _pinTextField(_thirdDigit.value),
+                  _pinTextField(_fourthDigit.value),
                 ],
               ),
             ),
@@ -143,63 +187,5 @@ class _LockRegisterState extends State<LockRegister> {
         ),
       ),
     );
-  }
-
-  void _setCurrentDigit(int i) {
-    setState(() {
-      _currentDigit = i;
-      if (_firstDigit == null) {
-        _firstDigit = _currentDigit;
-      } else if (_secondDigit == null) {
-        _secondDigit = _currentDigit;
-      } else if (_thirdDigit == null) {
-        _thirdDigit = _currentDigit;
-      } else if (_fourthDigit == null) {
-        _fourthDigit = _currentDigit;
-
-        _pin = _firstDigit.toString() +
-            _secondDigit.toString() +
-            _thirdDigit.toString() +
-            _fourthDigit.toString();
-
-        print(_pin);
-      }
-    });
-  }
-
-  void _deleteCurrentDigit() {
-    setState(() {
-      if (_fourthDigit != null) {
-        _fourthDigit = null;
-      } else if (_thirdDigit != null) {
-        _thirdDigit = null;
-      } else if (_secondDigit != null) {
-        _secondDigit = null;
-      } else if (_firstDigit != null) {
-        _firstDigit = null;
-      }
-    });
-  }
-
-  Widget _pinTextField(int? digit) {
-    return Container(
-        width: 50,
-        height: 45,
-        alignment: Alignment.center,
-        child: Text(
-          digit != null ? digit.toString() : "",
-          style: TextStyle(
-            fontSize: 30,
-            color: Theme.of(context).textTheme.displayLarge!.color,
-          ),
-        ),
-        decoration: BoxDecoration(
-          border: Border(
-            bottom: BorderSide(
-              color: Theme.of(context).textTheme.displayLarge!.color!,
-              width: 2,
-            ),
-          ),
-        ));
   }
 }

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -81,7 +81,7 @@ class _LockRegisterState extends State<LockRegister> {
     _screenSize = MediaQuery.of(context).size;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         context: context,
         iconColor: Theme.of(context).textTheme.displayLarge!.color,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 
@@ -7,18 +8,13 @@ import 'package:wecount/utils/localization.dart' show Localization;
 
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
-class MainEmpty extends StatefulWidget {
+class MainEmpty extends HookWidget {
   const MainEmpty({
     Key? key,
     this.title = '',
   }) : super(key: key);
   final String title;
 
-  @override
-  _MainEmptyState createState() => _MainEmptyState();
-}
-
-class _MainEmptyState extends State<MainEmpty> {
   @override
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -36,7 +36,7 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, Setting.name),
+              onPressed: () => navigation.push(context, 'setting'),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,
@@ -87,7 +87,7 @@ class _MainEmptyState extends State<MainEmpty> {
                   ),
                 ),
               ),
-              onPress: () => Navigator.of(context).pushNamed(LedgerEdit.name),
+              onPress: () => Navigator.of(context).pushNamed("ledger-edit"),
               text: _localization.trans('ADD_LEDGER'),
               textStyle: TextStyle(
                 fontSize: 20,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -26,7 +26,7 @@ class _MainEmptyState extends State<MainEmpty> {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHomeAppBar(
         context: context,
         title: '',
@@ -47,7 +47,7 @@ class _MainEmptyState extends State<MainEmpty> {
         ],
       ),
       body: Container(
-        color: Theme.of(context).backgroundColor,
+        color: Theme.of(context).colorScheme.background,
         width: double.infinity,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -78,12 +78,14 @@ class _MainEmptyState extends State<MainEmpty> {
               backgroundColor: Colors.transparent,
               width: 160,
               height: 56,
-              shapeBorder: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(32),
-                side: BorderSide(
-                  color: Theme.of(context).textTheme.displayMedium!.color!,
-                  width: 1,
-                  style: BorderStyle.solid,
+              shapeBorder: MaterialStatePropertyAll<OutlinedBorder>(
+                RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(32),
+                  side: BorderSide(
+                    color: Theme.of(context).textTheme.displayMedium!.color!,
+                    width: 1,
+                    style: BorderStyle.solid,
+                  ),
                 ),
               ),
               onPress: () => Navigator.of(context).pushNamed(LedgerEdit.name),

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:wecount/screens/ledger_edit.dart';
 import 'package:wecount/screens/setting.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
 class MainEmpty extends StatefulWidget {
-  static const String name = '/main_empty';
+  static const String name = '/main-empty';
 
   MainEmpty({
     Key? key,
@@ -36,8 +36,7 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () =>
-                  General.instance.navigateScreenNamed(context, Setting.name),
+              onPressed: () => navigation.push(context, Setting.name),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -33,8 +33,7 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () =>
-                  navigation.push(context, AppRoute.setting.fullPath),
+              onPressed: () => navigation.push(context, AppRoute.setting.path),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:wecount/screens/ledger_edit.dart';
-import 'package:wecount/screens/setting.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/localization.dart' show Localization;
@@ -9,9 +8,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
 class MainEmpty extends StatefulWidget {
-  static const String name = '/main-empty';
-
-  MainEmpty({
+  const MainEmpty({
     Key? key,
     this.title = '',
   }) : super(key: key);
@@ -36,7 +33,8 @@ class _MainEmptyState extends State<MainEmpty> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () => navigation.push(context, 'setting'),
+              onPressed: () =>
+                  navigation.push(context, AppRoute.setting.fullPath),
               child: Icon(
                 Icons.settings,
                 color: Colors.white,
@@ -87,7 +85,8 @@ class _MainEmptyState extends State<MainEmpty> {
                   ),
                 ),
               ),
-              onPress: () => Navigator.of(context).pushNamed("ledger-edit"),
+              onPress: () =>
+                  Navigator.of(context).pushNamed(AppRoute.ledgerEdit.fullPath),
               text: _localization.trans('ADD_LEDGER'),
               textStyle: TextStyle(
                 fontSize: 20,

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,4 +1,5 @@
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/edit_text.dart';
 import 'package:flutter/material.dart';
 
@@ -16,10 +17,8 @@ class MembersArguments {
 }
 
 class Members extends StatefulWidget {
-  static const String name = '/members';
-
   final Ledger? ledger;
-  Members({Key? key, this.ledger}) : super(key: key);
+  const Members({Key? key, this.ledger}) : super(key: key);
 
   @override
   _MembersState createState() => _MembersState();
@@ -197,7 +196,7 @@ class _MembersState extends State<Members> {
                 }, item.user.membership!.index);
               },
               onPressMember: () {
-                navigation.navigate(context, 'profile-peer',
+                navigation.navigate(context, AppRoute.profilePeer.fullPath,
                     arguments: ProfilePeerArguments(
                       user: item.user,
                     ));

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -110,7 +110,7 @@ class _MembersState extends State<Members> {
     var _localization = Localization.of(context)!;
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -196,7 +196,7 @@ class _MembersState extends State<Members> {
                 }, item.user.membership!.index);
               },
               onPressMember: () {
-                navigation.navigate(context, AppRoute.profilePeer.fullPath,
+                navigation.navigate(context, AppRoute.profilePeer.path,
                     arguments: ProfilePeerArguments(
                       user: item.user,
                     ));

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,15 +1,23 @@
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/edit_text.dart';
 import 'package:flutter/material.dart';
 
 import 'package:wecount/screens/profile_peer.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/widgets/member_list_item.dart';
 import 'package:wecount/widgets/header.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/models/ledger.dart';
 import 'package:wecount/utils/localization.dart';
 
+class MembersArguments {
+  final Ledger? ledger;
+
+  MembersArguments({this.ledger});
+}
+
 class Members extends StatefulWidget {
+  static const String name = '/members';
+
   final Ledger? ledger;
   Members({Key? key, this.ledger}) : super(key: key);
 
@@ -181,7 +189,7 @@ class _MembersState extends State<Members> {
             return MemberListItem(
               user: item.user,
               onPressAuth: () {
-                General.instance.showMembershipDialog(context, (int? val) {
+                navigation.showMembershipDialog(context, (int? val) {
                   setState(() {
                     item.user.changeMemberShip(val!);
                   });
@@ -189,12 +197,9 @@ class _MembersState extends State<Members> {
                 }, item.user.membership!.index);
               },
               onPressMember: () {
-                General.instance.navigateScreen(
-                    context,
-                    MaterialPageRoute(
-                      builder: (BuildContext context) => ProfilePeer(
-                        user: item.user,
-                      ),
+                navigation.navigate(context, 'profile-peer',
+                    arguments: ProfilePeerArguments(
+                      user: item.user,
                     ));
               },
             );

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/edit_text.dart';
@@ -16,104 +17,97 @@ class MembersArguments {
   MembersArguments({this.ledger});
 }
 
-class Members extends StatefulWidget {
+class Members extends HookWidget {
   final Ledger? ledger;
   const Members({Key? key, this.ledger}) : super(key: key);
 
   @override
-  _MembersState createState() => _MembersState();
-}
-
-class _MembersState extends State<Members> {
-  bool _isSearchMode = false;
-  List<ListItem> _filteredMembers = [];
-
-  final List<ListItem> _fakeMembers = [
-    HeadingItem(
-      numOfPeople: 4,
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Owner,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Admin,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Admin,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-  ];
-
-  @override
-  void initState() {
-    super.initState();
-    _filteredMembers = _fakeMembers;
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _isSearchMode = useState<bool>(false);
+    var _filteredMembers = useState<List<ListItem>>([]);
+
+    final List<ListItem> _fakeMembers = [
+      HeadingItem(
+        numOfPeople: 4,
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Owner,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Admin,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Admin,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+    ];
+
+    useEffect(() {
+      _filteredMembers.value = _fakeMembers;
+      return null;
+    }, []);
     var _localization = Localization.of(context)!;
 
     return Scaffold(
@@ -128,12 +122,10 @@ class _MembersState extends State<Members> {
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
               onPressed: () {
-                setState(() {
-                  _isSearchMode = !_isSearchMode;
-                  if (!_isSearchMode) {
-                    _filteredMembers = _fakeMembers;
-                  }
-                });
+                _isSearchMode.value = !_isSearchMode.value;
+                if (!_isSearchMode.value) {
+                  _filteredMembers.value = _fakeMembers;
+                }
               },
               child: Icon(
                 Icons.search,
@@ -145,35 +137,33 @@ class _MembersState extends State<Members> {
         ],
       ),
       body: ListView.builder(
-        itemCount: _filteredMembers.length,
+        itemCount: _filteredMembers.value.length,
         itemBuilder: (context, index) {
-          final item = _filteredMembers[index];
+          final item = _filteredMembers.value[index];
           if (item is HeadingItem) {
             return Container(
               height: 80,
               padding: EdgeInsets.symmetric(horizontal: 40),
               alignment: Alignment(-1, 0),
-              child: _isSearchMode
+              child: _isSearchMode.value
                   ? EditText(
                       key: Key('member'),
                       textInputAction: TextInputAction.next,
                       textHint: _localization.trans('SEARCH_USER_HINT'),
                       onChanged: (String str) {
-                        setState(() {
-                          _filteredMembers = _fakeMembers.where((list) {
-                            if (list is HeadingItem) {
-                              return true;
-                            } else if (list is MemberItem) {
-                              return list.user.email!
-                                      .toLowerCase()
-                                      .contains(str) ||
-                                  list.user.displayName!
-                                      .toLowerCase()
-                                      .contains(str);
-                            }
-                            return false;
-                          }).toList();
-                        });
+                        _filteredMembers.value = _fakeMembers.where((list) {
+                          if (list is HeadingItem) {
+                            return true;
+                          } else if (list is MemberItem) {
+                            return list.user.email!
+                                    .toLowerCase()
+                                    .contains(str) ||
+                                list.user.displayName!
+                                    .toLowerCase()
+                                    .contains(str);
+                          }
+                          return false;
+                        }).toList();
                       },
                     )
                   : Text(
@@ -189,9 +179,7 @@ class _MembersState extends State<Members> {
               user: item.user,
               onPressAuth: () {
                 navigation.showMembershipDialog(context, (int? val) {
-                  setState(() {
-                    item.user.changeMemberShip(val!);
-                  });
+                  item.user.changeMemberShip(val!);
                   Navigator.of(context).pop();
                 }, item.user.membership!.index);
               },

--- a/lib/screens/photo_detail.dart
+++ b/lib/screens/photo_detail.dart
@@ -7,7 +7,27 @@ import 'package:flutter/material.dart';
 import 'package:wecount/models/photo.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 
+class PhotoDetailArguments {
+  final Photo? photo;
+  final String? photoUrl;
+  final bool canShare;
+  final Function? onPressDelete;
+  final Function? onPressShare;
+  final Function? onPressDownload;
+
+  PhotoDetailArguments({
+    this.photo,
+    this.photoUrl,
+    this.canShare = false,
+    this.onPressDelete,
+    this.onPressShare,
+    this.onPressDownload,
+  });
+}
+
 class PhotoDetail extends StatefulWidget {
+  static const String name = '/photo-detail';
+
   PhotoDetail({
     Key? key,
     this.photo,

--- a/lib/screens/photo_detail.dart
+++ b/lib/screens/photo_detail.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:photo_view/photo_view.dart'
     show PhotoView, PhotoViewComputedScale;
 import 'package:flutter/material.dart';
@@ -25,7 +26,7 @@ class PhotoDetailArguments {
   });
 }
 
-class PhotoDetail extends StatefulWidget {
+class PhotoDetail extends HookWidget {
   const PhotoDetail({
     Key? key,
     this.photo,
@@ -43,11 +44,6 @@ class PhotoDetail extends StatefulWidget {
   final Function? onPressDownload;
 
   @override
-  _State createState() => _State();
-}
-
-class _State extends State<PhotoDetail> {
-  @override
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
@@ -56,12 +52,12 @@ class _State extends State<PhotoDetail> {
         child: Stack(
           children: <Widget>[
             PhotoView(
-              imageProvider: widget.photoUrl != null
-                  ? NetworkImage(widget.photoUrl!)
-                  : widget.photo != null && widget.photo!.file != null
-                      ? FileImage(File(widget.photo!.file!.path))
-                      : (widget.photo != null && widget.photo!.url != null
-                              ? NetworkImage(widget.photo!.url!)
+              imageProvider: photoUrl != null
+                  ? NetworkImage(photoUrl!)
+                  : photo != null && photo!.file != null
+                      ? FileImage(File(photo!.file!.path))
+                      : (photo != null && photo!.url != null
+                              ? NetworkImage(photo!.url!)
                               : AssetImage('res/icons/icMask.png'))
                           as ImageProvider<Object>?,
               minScale: PhotoViewComputedScale.contained * 0.8,
@@ -96,19 +92,18 @@ class _State extends State<PhotoDetail> {
                 height: 56,
                 width: MediaQuery.of(context).size.width,
                 child: Row(
-                  mainAxisAlignment: widget.canShare
+                  mainAxisAlignment: canShare
                       ? MainAxisAlignment.spaceAround
                       : MainAxisAlignment.center,
                   children: <Widget>[
-                    widget.canShare
+                    canShare
                         ? Container(
                             width: 60.0,
                             height: 60.0,
                             child: RawMaterialButton(
                               padding: EdgeInsets.all(0.0),
                               shape: CircleBorder(),
-                              onPressed:
-                                  widget.onPressDownload as void Function()?,
+                              onPressed: onPressDownload as void Function()?,
                               child: Icon(
                                 Icons.file_download,
                                 color: Colors.white,
@@ -116,15 +111,14 @@ class _State extends State<PhotoDetail> {
                             ),
                           )
                         : Container(),
-                    widget.canShare
+                    canShare
                         ? Container(
                             width: 60.0,
                             height: 60.0,
                             child: RawMaterialButton(
                               padding: EdgeInsets.all(0.0),
                               shape: CircleBorder(),
-                              onPressed:
-                                  widget.onPressShare as void Function()?,
+                              onPressed: onPressShare as void Function()?,
                               child: Icon(
                                 Icons.share,
                                 color: Colors.white,
@@ -132,15 +126,14 @@ class _State extends State<PhotoDetail> {
                             ),
                           )
                         : Container(),
-                    widget.onPressDelete != null
+                    onPressDelete != null
                         ? Container(
                             width: 60.0,
                             height: 60.0,
                             child: RawMaterialButton(
                               padding: EdgeInsets.all(0.0),
                               shape: CircleBorder(),
-                              onPressed:
-                                  widget.onPressDelete as void Function()?,
+                              onPressed: onPressDelete as void Function()?,
                               child: Icon(
                                 Icons.delete,
                                 color: Colors.white,

--- a/lib/screens/photo_detail.dart
+++ b/lib/screens/photo_detail.dart
@@ -26,9 +26,7 @@ class PhotoDetailArguments {
 }
 
 class PhotoDetail extends StatefulWidget {
-  static const String name = '/photo-detail';
-
-  PhotoDetail({
+  const PhotoDetail({
     Key? key,
     this.photo,
     this.photoUrl,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -18,13 +18,13 @@ class ProfileMy extends HookWidget {
   @override
   Widget build(BuildContext context) {
     var _imgFile = useState<XFile?>(null);
-    var _profile = useState<User?>(null);
+    User? _profile;
 
     Future<void> _onUpdateProfile() async {
       navigation.showDialogSpinner(context);
 
       await DatabaseService().requestUpdateProfile(
-        _profile.value,
+        _profile,
         imgFile: _imgFile.value,
       );
 
@@ -59,7 +59,7 @@ class ProfileMy extends HookWidget {
           if (!snapshot.hasData) return Container();
 
           var user = snapshot.data;
-          _profile.value = User(
+          _profile = User(
             email: user.email ?? '',
             displayName: user.displayName ?? '',
             phoneNumber: user.phoneNumber ?? '',
@@ -78,9 +78,9 @@ class ProfileMy extends HookWidget {
                   children: <Widget>[
                     ProfileImageCam(
                       imgFile: _imgFile.value,
-                      imgStr: _profile.value!.thumbURL != null
-                          ? _profile.value!.thumbURL
-                          : _profile.value!.photoURL,
+                      imgStr: _profile?.thumbURL != null
+                          ? _profile!.thumbURL
+                          : _profile?.photoURL,
                       selectCamera: () async {
                         var file = await navigation.chooseImage(
                             context: context, type: 'camera');
@@ -114,7 +114,7 @@ class ProfileMy extends HookWidget {
                 controller: TextEditingController(
                   text: user.displayName,
                 ),
-                onChangeText: (String str) => _profile.value!.displayName = str,
+                onChangeText: (String str) => _profile?.displayName = str,
                 semanticLabel: _localization.trans('NICKNAME'),
                 iconData: Icons.person_outline,
                 margin: EdgeInsets.only(top: 8.0),
@@ -126,7 +126,7 @@ class ProfileMy extends HookWidget {
                 controller: TextEditingController(
                   text: user.phoneNumber,
                 ),
-                onChangeText: (String str) => _profile.value!.phoneNumber = str,
+                onChangeText: (String str) => _profile?.phoneNumber = str,
                 iconData: Icons.phone,
                 margin: EdgeInsets.only(top: 8.0),
                 hintText: _localization.trans('PHONE'),
@@ -143,7 +143,7 @@ class ProfileMy extends HookWidget {
                 controller: TextEditingController(
                   text: user.statusMsg,
                 ),
-                onChangeText: (String str) => _profile.value!.statusMsg = str,
+                onChangeText: (String str) => _profile?.statusMsg = str,
                 labelText: _localization.trans('STATUS_MESSAGE'),
                 hintText: _localization.trans('STATUS_MESSAGE_HINT'),
                 maxLines: 5,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -40,7 +40,7 @@ class _ProfileMyState extends State<ProfileMy> {
     var _user = Provider.of<FireAuth.User>(context);
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -2,17 +2,17 @@ import 'package:wecount/models/user.dart' show User;
 import 'package:wecount/services/database.dart';
 import 'package:firebase_auth/firebase_auth.dart' as FireAuth show User;
 import 'package:flutter/material.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/widgets/edit_text_box.dart' show EditTextBox;
 import 'package:wecount/widgets/profile_image_cam.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
 class ProfileMy extends StatefulWidget {
-  static const String name = '/profile_my';
+  static const String name = '/profile-my';
 
   @override
   _ProfileMyState createState() => _ProfileMyState();
@@ -23,7 +23,7 @@ class _ProfileMyState extends State<ProfileMy> {
   User? _profile;
 
   Future<void> _onUpdateProfile() async {
-    General.instance.showDialogSpinner(context);
+    navigation.showDialogSpinner(context);
 
     await DatabaseService().requestUpdateProfile(
       _profile,
@@ -86,15 +86,15 @@ class _ProfileMyState extends State<ProfileMy> {
                           ? _profile!.thumbURL
                           : _profile!.photoURL,
                       selectCamera: () async {
-                        var file = await General.instance
-                            .chooseImage(context: context, type: 'camera');
+                        var file = await navigation.chooseImage(
+                            context: context, type: 'camera');
                         if (file != null) {
                           setState(() => _imgFile = file);
                         }
                       },
                       selectGallery: () async {
-                        var file = await General.instance
-                            .chooseImage(context: context, type: 'gallery');
+                        var file = await navigation.chooseImage(
+                            context: context, type: 'gallery');
                         if (file != null) {
                           setState(() => _imgFile = file);
                         }

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/user.dart' show User;
 import 'package:wecount/services/database.dart';
 import 'package:firebase_auth/firebase_auth.dart' as FireAuth show User;
@@ -11,31 +12,26 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
-class ProfileMy extends StatefulWidget {
+class ProfileMy extends HookWidget {
   const ProfileMy({Key? key}) : super(key: key);
 
   @override
-  _ProfileMyState createState() => _ProfileMyState();
-}
-
-class _ProfileMyState extends State<ProfileMy> {
-  XFile? _imgFile;
-  User? _profile;
-
-  Future<void> _onUpdateProfile() async {
-    navigation.showDialogSpinner(context);
-
-    await DatabaseService().requestUpdateProfile(
-      _profile,
-      imgFile: _imgFile,
-    );
-
-    Navigator.of(context).pop();
-    Navigator.of(context).pop();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _imgFile = useState<XFile?>(null);
+    var _profile = useState<User?>(null);
+
+    Future<void> _onUpdateProfile() async {
+      navigation.showDialogSpinner(context);
+
+      await DatabaseService().requestUpdateProfile(
+        _profile.value,
+        imgFile: _imgFile.value,
+      );
+
+      Navigator.of(context).pop();
+      Navigator.of(context).pop();
+    }
+
     var _localization = Localization.of(context)!;
     var _user = Provider.of<FireAuth.User>(context);
 
@@ -63,7 +59,7 @@ class _ProfileMyState extends State<ProfileMy> {
           if (!snapshot.hasData) return Container();
 
           var user = snapshot.data;
-          _profile = User(
+          _profile.value = User(
             email: user.email ?? '',
             displayName: user.displayName ?? '',
             phoneNumber: user.phoneNumber ?? '',
@@ -81,22 +77,22 @@ class _ProfileMyState extends State<ProfileMy> {
                 child: Row(
                   children: <Widget>[
                     ProfileImageCam(
-                      imgFile: _imgFile,
-                      imgStr: _profile!.thumbURL != null
-                          ? _profile!.thumbURL
-                          : _profile!.photoURL,
+                      imgFile: _imgFile.value,
+                      imgStr: _profile.value!.thumbURL != null
+                          ? _profile.value!.thumbURL
+                          : _profile.value!.photoURL,
                       selectCamera: () async {
                         var file = await navigation.chooseImage(
                             context: context, type: 'camera');
                         if (file != null) {
-                          setState(() => _imgFile = file);
+                          _imgFile.value = file;
                         }
                       },
                       selectGallery: () async {
                         var file = await navigation.chooseImage(
                             context: context, type: 'gallery');
                         if (file != null) {
-                          setState(() => _imgFile = file);
+                          _imgFile.value = file;
                         }
                       },
                     ),
@@ -118,7 +114,7 @@ class _ProfileMyState extends State<ProfileMy> {
                 controller: TextEditingController(
                   text: user.displayName,
                 ),
-                onChangeText: (String str) => _profile!.displayName = str,
+                onChangeText: (String str) => _profile.value!.displayName = str,
                 semanticLabel: _localization.trans('NICKNAME'),
                 iconData: Icons.person_outline,
                 margin: EdgeInsets.only(top: 8.0),
@@ -130,7 +126,7 @@ class _ProfileMyState extends State<ProfileMy> {
                 controller: TextEditingController(
                   text: user.phoneNumber,
                 ),
-                onChangeText: (String str) => _profile!.phoneNumber = str,
+                onChangeText: (String str) => _profile.value!.phoneNumber = str,
                 iconData: Icons.phone,
                 margin: EdgeInsets.only(top: 8.0),
                 hintText: _localization.trans('PHONE'),
@@ -147,7 +143,7 @@ class _ProfileMyState extends State<ProfileMy> {
                 controller: TextEditingController(
                   text: user.statusMsg,
                 ),
-                onChangeText: (String str) => _profile!.statusMsg = str,
+                onChangeText: (String str) => _profile.value!.statusMsg = str,
                 labelText: _localization.trans('STATUS_MESSAGE'),
                 hintText: _localization.trans('STATUS_MESSAGE_HINT'),
                 maxLines: 5,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -12,7 +12,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
 class ProfileMy extends StatefulWidget {
-  static const String name = '/profile-my';
+  const ProfileMy({Key? key}) : super(key: key);
 
   @override
   _ProfileMyState createState() => _ProfileMyState();

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -35,7 +35,7 @@ class _ProfilePeerState extends State<ProfilePeer> {
     Localization.of(context);
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderClose(
         context: context,
         brightness: Theme.of(context).brightness,

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -1,13 +1,20 @@
 import 'package:wecount/models/user.dart';
 import 'package:wecount/screens/photo_detail.dart';
 import 'package:flutter/material.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/widgets/edit_text_box.dart' show EditTextBox;
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart' show Localization;
 
+class ProfilePeerArguments {
+  final User user;
+
+  ProfilePeerArguments({required this.user});
+}
+
 class ProfilePeer extends StatefulWidget {
+  static const String name = '/profile-peer';
   final User user;
 
   ProfilePeer({
@@ -20,12 +27,11 @@ class ProfilePeer extends StatefulWidget {
 
 class _ProfilePeerState extends State<ProfilePeer> {
   void showImage(String photoUrl) async {
-    await General.instance.navigateScreen(
+    await navigation.navigate(
       context,
-      MaterialPageRoute(
-        builder: (BuildContext context) => PhotoDetail(
-          photoUrl: photoUrl,
-        ),
+      'photo-detail',
+      arguments: PhotoDetailArguments(
+        photoUrl: photoUrl,
       ),
     );
   }

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -2,6 +2,7 @@ import 'package:wecount/models/user.dart';
 import 'package:wecount/screens/photo_detail.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderClose;
 import 'package:wecount/widgets/edit_text_box.dart' show EditTextBox;
@@ -14,10 +15,8 @@ class ProfilePeerArguments {
 }
 
 class ProfilePeer extends StatefulWidget {
-  static const String name = '/profile-peer';
   final User user;
-
-  ProfilePeer({
+  const ProfilePeer({
     required this.user,
   });
 
@@ -29,7 +28,7 @@ class _ProfilePeerState extends State<ProfilePeer> {
   void showImage(String photoUrl) async {
     await navigation.navigate(
       context,
-      'photo-detail',
+      AppRoute.photoDetail.fullPath,
       arguments: PhotoDetailArguments(
         photoUrl: photoUrl,
       ),

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -28,7 +28,7 @@ class _ProfilePeerState extends State<ProfilePeer> {
   void showImage(String photoUrl) async {
     await navigation.navigate(
       context,
-      AppRoute.photoDetail.fullPath,
+      AppRoute.photoDetail.path,
       arguments: PhotoDetailArguments(
         photoUrl: photoUrl,
       ),

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/screens/photo_detail.dart';
 import 'package:flutter/material.dart';
@@ -14,29 +15,24 @@ class ProfilePeerArguments {
   ProfilePeerArguments({required this.user});
 }
 
-class ProfilePeer extends StatefulWidget {
+class ProfilePeer extends HookWidget {
   final User user;
   const ProfilePeer({
     required this.user,
   });
 
   @override
-  _ProfilePeerState createState() => _ProfilePeerState();
-}
-
-class _ProfilePeerState extends State<ProfilePeer> {
-  void showImage(String photoUrl) async {
-    await navigation.navigate(
-      context,
-      AppRoute.photoDetail.path,
-      arguments: PhotoDetailArguments(
-        photoUrl: photoUrl,
-      ),
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
+    void showImage(String photoUrl) async {
+      await navigation.navigate(
+        context,
+        AppRoute.photoDetail.path,
+        arguments: PhotoDetailArguments(
+          photoUrl: photoUrl,
+        ),
+      );
+    }
+
     Localization.of(context);
 
     return Scaffold(

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -8,11 +8,11 @@ import 'package:wecount/screens/setting_faq.dart';
 import 'package:wecount/screens/setting_notification.dart';
 import 'package:wecount/screens/setting_opinion.dart';
 import 'package:wecount/screens/tutorial.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/setting_list_item.dart'
     show ListItem, LogoutItem, SettingItem, SettingListItem;
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart' show Localization;
 
@@ -62,7 +62,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await General.instance.navigateScreenNamed(context, LockRegister.name);
+    await navigation.push(context, LockRegister.name);
 
     setState(() {
       readLockPinFromSF();
@@ -70,8 +70,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result =
-        await General.instance.navigateScreenNamed(context, LockAuth.name);
+    final result = await navigation.push(context, LockAuth.name);
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -92,8 +91,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('ANNOUNCEMENT'),
-        onPressed: () => General.instance
-            .navigateScreenNamed(context, SettingAnnouncement.name),
+        onPressed: () => navigation.push(context, SettingAnnouncement.name),
       ),
       SettingItem(
         Icon(
@@ -102,8 +100,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () =>
-            General.instance.navigateScreenNamed(context, SettingOpinion.name),
+        onPressed: () => navigation.push(context, SettingOpinion.name),
       ),
       SettingItem(
         Icon(
@@ -112,8 +109,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () =>
-            General.instance.navigateScreenNamed(context, SettingFAQ.name),
+        onPressed: () => navigation.push(context, SettingFAQ.name),
       ),
       SettingItem(
         Icon(
@@ -122,8 +118,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('NOTIFICATION'),
-        onPressed: () => General.instance
-            .navigateScreenNamed(context, SettingNotification.name),
+        onPressed: () => navigation.push(context, SettingNotification.name),
       ),
       SettingItem(
         Icon(
@@ -145,8 +140,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          General.instance
-              .navigateScreenNamed(context, Tutorial.name, reset: true);
+          navigation.push(context, Tutorial.name, reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -56,7 +56,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await navigation.push(context, AppRoute.lockRegister.fullPath);
+    await navigation.push(context, AppRoute.lockRegister.path);
 
     setState(() {
       readLockPinFromSF();
@@ -64,7 +64,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result = await navigation.push(context, AppRoute.lockAuth.fullPath);
+    final result = await navigation.push(context, AppRoute.lockAuth.path);
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -86,7 +86,7 @@ class _SettingState extends State<Setting> {
         ),
         _localization.trans('ANNOUNCEMENT'),
         onPressed: () =>
-            navigation.push(context, AppRoute.settingAnnouncement.fullPath),
+            navigation.push(context, AppRoute.settingAnnouncement.path),
       ),
       SettingItem(
         Icon(
@@ -95,8 +95,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () =>
-            navigation.push(context, AppRoute.settingOpinion.fullPath),
+        onPressed: () => navigation.push(context, AppRoute.settingOpinion.path),
       ),
       SettingItem(
         Icon(
@@ -105,7 +104,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () => navigation.push(context, AppRoute.settingFAQ.fullPath),
+        onPressed: () => navigation.push(context, AppRoute.settingFAQ.path),
       ),
       SettingItem(
         Icon(
@@ -115,7 +114,7 @@ class _SettingState extends State<Setting> {
         ),
         _localization.trans('NOTIFICATION'),
         onPressed: () =>
-            navigation.push(context, AppRoute.settingNotification.fullPath),
+            navigation.push(context, AppRoute.settingNotification.path),
       ),
       SettingItem(
         Icon(
@@ -137,7 +136,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          navigation.push(context, AppRoute.tutorial.fullPath, reset: true);
+          navigation.push(context, AppRoute.tutorial.path, reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -1,14 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:wecount/screens/lock_auth.dart';
-import 'package:wecount/screens/lock_register.dart';
-import 'package:wecount/screens/setting_announcement.dart';
-import 'package:wecount/screens/setting_faq.dart';
-import 'package:wecount/screens/setting_notification.dart';
-import 'package:wecount/screens/setting_opinion.dart';
-import 'package:wecount/screens/tutorial.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/setting_list_item.dart'
     show ListItem, LogoutItem, SettingItem, SettingListItem;
@@ -19,7 +13,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 FirebaseAuth _auth = FirebaseAuth.instance;
 
 class Setting extends StatefulWidget {
-  static const String name = '/setting';
+  const Setting({Key? key}) : super(key: key);
 
   @override
   _SettingState createState() => _SettingState();
@@ -62,7 +56,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await navigation.push(context, "lock-register");
+    await navigation.push(context, AppRoute.lockRegister.fullPath);
 
     setState(() {
       readLockPinFromSF();
@@ -70,7 +64,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result = await navigation.push(context, "lock-auth");
+    final result = await navigation.push(context, AppRoute.lockAuth.fullPath);
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -91,7 +85,8 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('ANNOUNCEMENT'),
-        onPressed: () => navigation.push(context, "setting-announcement"),
+        onPressed: () =>
+            navigation.push(context, AppRoute.settingAnnouncement.fullPath),
       ),
       SettingItem(
         Icon(
@@ -100,7 +95,8 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () => navigation.push(context, "setting-opinion"),
+        onPressed: () =>
+            navigation.push(context, AppRoute.settingOpinion.fullPath),
       ),
       SettingItem(
         Icon(
@@ -109,7 +105,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () => navigation.push(context, "setting-faq"),
+        onPressed: () => navigation.push(context, AppRoute.settingFAQ.fullPath),
       ),
       SettingItem(
         Icon(
@@ -118,7 +114,8 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('NOTIFICATION'),
-        onPressed: () => navigation.push(context, "setting-notification"),
+        onPressed: () =>
+            navigation.push(context, AppRoute.settingNotification.fullPath),
       ),
       SettingItem(
         Icon(
@@ -140,7 +137,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          navigation.push(context, 'tutorial', reset: true);
+          navigation.push(context, AppRoute.tutorial.fullPath, reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -62,7 +62,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockRegister(BuildContext context) async {
-    await navigation.push(context, LockRegister.name);
+    await navigation.push(context, "lock-register");
 
     setState(() {
       readLockPinFromSF();
@@ -70,7 +70,7 @@ class _SettingState extends State<Setting> {
   }
 
   void _awaitLockAuth(BuildContext context) async {
-    final result = await navigation.push(context, LockAuth.name);
+    final result = await navigation.push(context, "lock-auth");
 
     setState(() {
       if (_lockSwitch == true && result == false) {
@@ -91,7 +91,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('ANNOUNCEMENT'),
-        onPressed: () => navigation.push(context, SettingAnnouncement.name),
+        onPressed: () => navigation.push(context, "setting-announcement"),
       ),
       SettingItem(
         Icon(
@@ -100,7 +100,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('SHARE_OPINION'),
-        onPressed: () => navigation.push(context, SettingOpinion.name),
+        onPressed: () => navigation.push(context, "setting-opinion"),
       ),
       SettingItem(
         Icon(
@@ -109,7 +109,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('FAQ'),
-        onPressed: () => navigation.push(context, SettingFAQ.name),
+        onPressed: () => navigation.push(context, "setting-faq"),
       ),
       SettingItem(
         Icon(
@@ -118,7 +118,7 @@ class _SettingState extends State<Setting> {
           size: 24,
         ),
         _localization.trans('NOTIFICATION'),
-        onPressed: () => navigation.push(context, SettingNotification.name),
+        onPressed: () => navigation.push(context, "setting-notification"),
       ),
       SettingItem(
         Icon(
@@ -140,7 +140,7 @@ class _SettingState extends State<Setting> {
           _auth.signOut();
 
           /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-          navigation.push(context, Tutorial.name, reset: true);
+          navigation.push(context, 'tutorial', reset: true);
         },
       ),
     ];

--- a/lib/screens/setting.dart
+++ b/lib/screens/setting.dart
@@ -152,7 +152,7 @@ class _SettingState extends State<Setting> {
     ];
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         context: context,
         iconColor: Theme.of(context).iconTheme.color,

--- a/lib/screens/setting_announcement.dart
+++ b/lib/screens/setting_announcement.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingAnnouncement extends StatelessWidget {
-  static const String name = '/setting_announcement';
+  static const String name = '/setting-announcement';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_announcement.dart
+++ b/lib/screens/setting_announcement.dart
@@ -48,7 +48,7 @@ class SettingAnnouncement extends StatelessWidget {
       ),
     ];
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_announcement.dart
+++ b/lib/screens/setting_announcement.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingAnnouncement extends StatelessWidget {
-  static const String name = '/setting-announcement';
+  const SettingAnnouncement({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -46,7 +46,7 @@ class _SettingCurrencyState extends State<SettingCurrency> {
         .toList();
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -14,9 +14,7 @@ class SettingCurrencyArguments {
 }
 
 class SettingCurrency extends StatefulWidget {
-  static const String name = '/setting_currency';
-
-  SettingCurrency({
+  const SettingCurrency({
     Key? key,
     this.title = '',
     this.selectedCurrency = '',

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -6,6 +6,13 @@ import '../widgets/header.dart' show renderHeaderBack;
 import '../widgets/setting_list_item.dart'
     show ListItem, TileItem, SettingTileItem;
 
+class SettingCurrencyArguments {
+  final String title;
+  final String? selectedCurrency;
+
+  SettingCurrencyArguments({this.title = '', this.selectedCurrency});
+}
+
 class SettingCurrency extends StatefulWidget {
   static const String name = '/setting_currency';
 

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/currency.dart';
 import 'package:flutter/material.dart';
 
@@ -13,7 +14,7 @@ class SettingCurrencyArguments {
   SettingCurrencyArguments({this.title = '', this.selectedCurrency});
 }
 
-class SettingCurrency extends StatefulWidget {
+class SettingCurrency extends HookWidget {
   const SettingCurrency({
     Key? key,
     this.title = '',
@@ -23,23 +24,18 @@ class SettingCurrency extends StatefulWidget {
   final String? selectedCurrency;
 
   @override
-  _SettingCurrencyState createState() => _SettingCurrencyState();
-}
-
-class _SettingCurrencyState extends State<SettingCurrency> {
-  void onSettingCurrency(Currency selectedCurrency) {
-    print('on setting currency ${selectedCurrency.toString()}');
-    Navigator.pop(context, selectedCurrency);
-  }
-
-  @override
   Widget build(BuildContext context) {
+    void onSettingCurrency(Currency selectedCurrency) {
+      print('on setting currency ${selectedCurrency.toString()}');
+      Navigator.pop(context, selectedCurrency);
+    }
+
     var _localization = Localization.of(context)!;
 
     final List<ListItem> _items = currencies
         .map((el) => TileItem(
               title: '${el.currency} | ${el.symbol}',
-              trailing: el.currency == widget.selectedCurrency
+              trailing: el.currency == selectedCurrency
                   ? Icon(Icons.check)
                   : Text(''),
               onTap: () => onSettingCurrency(Currency(

--- a/lib/screens/setting_excel.dart
+++ b/lib/screens/setting_excel.dart
@@ -6,7 +6,7 @@ import '../widgets/button.dart' show Button;
 import '../utils/asset.dart' as Asset;
 
 class SettingExcel extends StatelessWidget {
-  static const String name = '/setting-excel';
+  const SettingExcel({Key? key}) : super(key: key);
 
   void onExportExcel() {
     print('on send excel');

--- a/lib/screens/setting_excel.dart
+++ b/lib/screens/setting_excel.dart
@@ -16,7 +16,7 @@ class SettingExcel extends StatelessWidget {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_excel.dart
+++ b/lib/screens/setting_excel.dart
@@ -6,7 +6,7 @@ import '../widgets/button.dart' show Button;
 import '../utils/asset.dart' as Asset;
 
 class SettingExcel extends StatelessWidget {
-  static const String name = '/setting_excel';
+  static const String name = '/setting-excel';
 
   void onExportExcel() {
     print('on send excel');

--- a/lib/screens/setting_faq.dart
+++ b/lib/screens/setting_faq.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingFAQ extends StatelessWidget {
-  static const String name = '/setting_faq';
+  static const String name = '/setting-faq';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_faq.dart
+++ b/lib/screens/setting_faq.dart
@@ -84,7 +84,7 @@ class SettingFAQ extends StatelessWidget {
       ),
     ];
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_faq.dart
+++ b/lib/screens/setting_faq.dart
@@ -32,7 +32,7 @@ class EntryItem extends StatelessWidget {
 }
 
 class SettingFAQ extends StatelessWidget {
-  static const String name = '/setting-faq';
+  const SettingFAQ({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -1,32 +1,27 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/header.dart';
 import 'package:wecount/utils/localization.dart';
 
-class SettingNotification extends StatefulWidget {
+class SettingNotification extends HookWidget {
   const SettingNotification({Key? key}) : super(key: key);
 
   @override
-  _SettingNotificationState createState() => _SettingNotificationState();
-}
-
-class _SettingNotificationState extends State<SettingNotification> {
-  bool _addLedgerSwitch = false;
-  bool _updateLedgerSwitch = false;
-
-  void _onChangeAddingLedgerSwitch(bool value) {
-    setState(() => _addLedgerSwitch = value);
-    print('value: $value');
-  }
-
-  void _onChangeUpdateLedgerSwitch(bool value) {
-    setState(() => _updateLedgerSwitch = value);
-    print('value: $value');
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _addLedgerSwitch = useState<bool>(false);
+    var _updateLedgerSwitch = useState<bool>(false);
+
+    void _onChangeAddingLedgerSwitch(bool value) {
+      _addLedgerSwitch.value = value;
+      print('value: $value');
+    }
+
+    void _onChangeUpdateLedgerSwitch(bool value) {
+      _updateLedgerSwitch.value = value;
+      print('value: $value');
+    }
+
     var _localization = Localization.of(context)!;
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -66,7 +61,7 @@ class _SettingNotificationState extends State<SettingNotification> {
                 Container(
                   padding: EdgeInsets.only(left: 40, top: 16),
                   child: Switch(
-                    value: _addLedgerSwitch,
+                    value: _addLedgerSwitch.value,
                     onChanged: _onChangeAddingLedgerSwitch,
                     activeTrackColor: Theme.of(context).primaryColor,
                     activeColor: Theme.of(context).accentColor,
@@ -93,7 +88,7 @@ class _SettingNotificationState extends State<SettingNotification> {
                 Container(
                   padding: EdgeInsets.only(left: 40, top: 16),
                   child: Switch(
-                    value: _updateLedgerSwitch,
+                    value: _updateLedgerSwitch.value,
                     onChanged: _onChangeUpdateLedgerSwitch,
                     activeTrackColor: Theme.of(context).primaryColor,
                     activeColor: Theme.of(context).accentColor,

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -5,7 +5,7 @@ import 'package:wecount/widgets/header.dart';
 import 'package:wecount/utils/localization.dart';
 
 class SettingNotification extends StatefulWidget {
-  static const String name = '/setting_notification';
+  static const String name = '/setting-notification';
 
   @override
   _SettingNotificationState createState() => _SettingNotificationState();

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -64,7 +64,7 @@ class SettingNotification extends HookWidget {
                     value: _addLedgerSwitch.value,
                     onChanged: _onChangeAddingLedgerSwitch,
                     activeTrackColor: Theme.of(context).primaryColor,
-                    activeColor: Theme.of(context).accentColor,
+                    activeColor: Theme.of(context).colorScheme.secondary,
                   ),
                 ),
               ],

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -5,7 +5,7 @@ import 'package:wecount/widgets/header.dart';
 import 'package:wecount/utils/localization.dart';
 
 class SettingNotification extends StatefulWidget {
-  static const String name = '/setting-notification';
+  const SettingNotification({Key? key}) : super(key: key);
 
   @override
   _SettingNotificationState createState() => _SettingNotificationState();

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -29,7 +29,7 @@ class _SettingNotificationState extends State<SettingNotification> {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_opinion.dart
+++ b/lib/screens/setting_opinion.dart
@@ -16,7 +16,7 @@ class SettingOpinion extends StatelessWidget {
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: renderHeaderBack(
         centerTitle: false,
         context: context,

--- a/lib/screens/setting_opinion.dart
+++ b/lib/screens/setting_opinion.dart
@@ -6,7 +6,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
 
 class SettingOpinion extends StatelessWidget {
-  static const String name = '/setting-opinion';
+  const SettingOpinion({Key? key}) : super(key: key);
 
   void onSendOpinion() {
     print('on send opinion');

--- a/lib/screens/setting_opinion.dart
+++ b/lib/screens/setting_opinion.dart
@@ -6,7 +6,7 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
 
 class SettingOpinion extends StatelessWidget {
-  static const String name = '/setting_opinion';
+  static const String name = '/setting-opinion';
 
   void onSendOpinion() {
     print('on send opinion');

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 
@@ -12,144 +13,139 @@ import 'package:wecount/utils/validator.dart' show Validator;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-class SignIn extends StatefulWidget {
+class SignIn extends HookWidget {
   const SignIn({Key? key}) : super(key: key);
 
   @override
-  _SignInState createState() => _SignInState();
-}
+  Widget build(BuildContext context) {
+    Localization? _localization;
+    var _scrollController = useScrollController();
 
-class _SignInState extends State<SignIn> {
-  Localization? _localization;
-  ScrollController _scrollController = ScrollController();
+    var _email = useState<String>("").value;
+    var _password = useState<String?>(null).value;
 
-  late String _email;
-  String? _password;
+    var _isValidEmail = useState<bool>(false).value;
+    var _isValidPassword = useState<bool>(false).value;
 
-  bool _isValidEmail = false;
-  bool _isValidPassword = false;
+    var _errorEmail = useState<String?>('').value;
+    var _errorPassword = useState<String?>('').value;
 
-  String? _errorEmail;
-  String? _errorPassword;
+    var _isSigningIn = useState<bool>(false).value;
+    var _isResendingEmail = useState<bool>(false).value;
 
-  bool _isSigningIn = false;
-  bool _isResendingEmail = false;
+    void _signIn() async {
+      if (_auth.currentUser != null) {
+        _auth.signOut();
+      }
 
-  void _signIn() async {
-    if (_auth.currentUser != null) {
-      _auth.signOut();
-    }
-
-    if (!_isValidEmail) {
-      setState(() => _errorEmail = _localization!.trans('NO_VALID_EMAIL'));
-      return;
-    }
-
-    if (!_isValidPassword) {
-      setState(() => _errorPassword = _localization!.trans('PASSWORD_HINT'));
-      return;
-    }
-
-    setState(() => _isSigningIn = true);
-
-    UserCredential auth;
-    try {
-      auth = await _auth.signInWithEmailAndPassword(
-          email: _email, password: _password!);
-
-      /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-      if (auth.user != null && auth.user!.emailVerified) {
-        var snapshots = await _firestore
-            .collection('users')
-            .doc(auth.user!.uid)
-            .collection('ledgers')
-            .get();
-
-        var ledgers = snapshots.docs;
-
-        if (ledgers.length == 0) {
-          navigation.push(context, AppRoute.mainEmpty.path, reset: true);
-          return;
-        }
-
-        navigation.push(context, AppRoute.homeTab.path, reset: true);
+      if (!_isValidEmail) {
+        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
         return;
       }
-    } catch (err) {
-      setState(() => _isSigningIn = false);
-      switch (err) {
-        // case 'ERROR_INVALID_EMAIL':
-        //   setState(() => _errorEmail = _localization!.trans(err.currency));
-        //   break;
-        // case 'ERROR_WRONG_PASSWORD':
-        //   setState(() => _errorPassword = _localization!.trans(err.currency));
-        //   break;
-        case 'ERROR_USER_NOT_FOUND':
-        case 'ERROR_USER_DISABLED':
-        case 'ERROR_TOO_MANY_REQUESTS':
-        case 'ERROR_OPERATION_NOT_ALLOWED':
-          // General.instance.showSingleDialog(
-          //   context,
-          //   title: Text(_localization!.trans('ERROR')!),
-          //   content: Text(_localization!.trans(err.currency)!),
-          // );
-          break;
-      }
-      return;
-    }
 
-    if (auth.user != null && !auth.user!.emailVerified) {
-      navigation.showSingleDialog(
-        context,
-        title: Text(_localization!.trans('ERROR')!),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Text(_localization!.trans('EMAIL_NOT_VERIFIED')!),
-            Container(
-              margin: EdgeInsets.only(top: 32, bottom: 24),
-              child: Text(
-                _email,
-                style: TextStyle(
-                  fontSize: 24,
-                  color: Theme.of(context).secondaryHeaderColor,
+      if (!_isValidPassword) {
+        _errorPassword = _localization!.trans('PASSWORD_HINT');
+        return;
+      }
+
+      _isSigningIn = true;
+
+      UserCredential auth;
+      try {
+        auth = await _auth.signInWithEmailAndPassword(
+            email: _email, password: _password!);
+
+        /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
+        if (auth.user != null && auth.user!.emailVerified) {
+          var snapshots = await _firestore
+              .collection('users')
+              .doc(auth.user!.uid)
+              .collection('ledgers')
+              .get();
+
+          var ledgers = snapshots.docs;
+
+          if (ledgers.length == 0) {
+            navigation.push(context, AppRoute.mainEmpty.path, reset: true);
+            return;
+          }
+
+          navigation.push(context, AppRoute.homeTab.path, reset: true);
+          return;
+        }
+      } catch (err) {
+        _isSigningIn = false;
+        switch (err) {
+          // case 'ERROR_INVALID_EMAIL':
+          //   setState(() => _errorEmail = _localization!.trans(err.currency));
+          //   break;
+          // case 'ERROR_WRONG_PASSWORD':
+          //   setState(() => _errorPassword = _localization!.trans(err.currency));
+          //   break;
+          case 'ERROR_USER_NOT_FOUND':
+          case 'ERROR_USER_DISABLED':
+          case 'ERROR_TOO_MANY_REQUESTS':
+          case 'ERROR_OPERATION_NOT_ALLOWED':
+            // General.instance.showSingleDialog(
+            //   context,
+            //   title: Text(_localization!.trans('ERROR')!),
+            //   content: Text(_localization!.trans(err.currency)!),
+            // );
+            break;
+        }
+        return;
+      }
+
+      if (auth.user != null && !auth.user!.emailVerified) {
+        navigation.showSingleDialog(
+          context,
+          title: Text(_localization!.trans('ERROR')!),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(_localization!.trans('EMAIL_NOT_VERIFIED')!),
+              Container(
+                margin: EdgeInsets.only(top: 32, bottom: 24),
+                child: Text(
+                  _email,
+                  style: TextStyle(
+                    fontSize: 24,
+                    color: Theme.of(context).secondaryHeaderColor,
+                  ),
                 ),
               ),
-            ),
-            Button(
-              height: 40,
-              isLoading: _isResendingEmail,
-              onPress: () async {
-                setState(() => _isResendingEmail = true);
-                try {
-                  await auth.user!.sendEmailVerification();
-                } catch (err) {
-                  // print('unknown error occurred. ${err.message}');
-                } finally {
-                  setState(() => _isResendingEmail = false);
-                }
-              },
-              text: _localization!.trans('RESEND_EMAIL'),
-              textStyle: TextStyle(
-                color: Theme.of(context).accentColor,
-                fontSize: 16,
+              Button(
+                height: 40,
+                isLoading: _isResendingEmail,
+                onPress: () async {
+                  _isResendingEmail = true;
+                  try {
+                    await auth.user!.sendEmailVerification();
+                  } catch (err) {
+                    // print('unknown error occurred. ${err.message}');
+                  } finally {
+                    _isResendingEmail = false;
+                  }
+                },
+                text: _localization!.trans('RESEND_EMAIL'),
+                textStyle: TextStyle(
+                  color: Theme.of(context).accentColor,
+                  fontSize: 16,
+                ),
               ),
-            ),
-          ],
-        ),
-        onPress: () => _auth.signOut(),
-      );
+            ],
+          ),
+          onPress: () => _auth.signOut(),
+        );
+      }
     }
-  }
 
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
+    useEffect(() {
+      return () {
+        _scrollController.dispose();
+      };
+    }, []);
 
-  @override
-  Widget build(BuildContext context) {
     _localization = Localization.of(context);
     _scrollController = ScrollController(
       initialScrollOffset: 0.0,
@@ -177,16 +173,12 @@ class _SignInState extends State<SignIn> {
         hintStyle: TextStyle(color: Theme.of(context).hintColor),
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            this.setState(() {
-              _isValidEmail = true;
-              _errorEmail = null;
-              _email = str;
-            });
+            _isValidEmail = true;
+            _errorEmail = null;
+            _email = str;
           } else {
-            this.setState(() {
-              _isValidEmail = false;
-              _email = str;
-            });
+            _isValidEmail = false;
+            _email = str;
           }
         },
         errorText: _errorEmail,
@@ -207,16 +199,12 @@ class _SignInState extends State<SignIn> {
         hasChecked: isValidPassword,
         onChanged: (String str) {
           if (isValidPassword) {
-            this.setState(() {
-              _isValidPassword = true;
-              _errorPassword = null;
-              _password = str;
-            });
+            _isValidPassword = true;
+            _errorPassword = null;
+            _password = str;
           } else {
-            this.setState(() {
-              _isValidPassword = false;
-              _password = str;
-            });
+            _isValidPassword = false;
+            _password = str;
           }
         },
         errorText: _errorPassword,

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:wecount/navigations/home_tab.dart';
-import 'package:wecount/screens/find_pw.dart';
-import 'package:wecount/screens/main_empty.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/widgets/edit_text.dart' show EditText;
@@ -15,9 +13,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
 class SignIn extends StatefulWidget {
-  static const String name = '/sign-in';
-
-  SignIn({Key? key}) : super(key: key);
+  const SignIn({Key? key}) : super(key: key);
 
   @override
   _SignInState createState() => _SignInState();
@@ -72,11 +68,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          navigation.push(context, 'main-empty', reset: true);
+          navigation.push(context, AppRoute.mainEmpty.fullPath, reset: true);
           return;
         }
 
-        navigation.push(context, 'home-tab', reset: true);
+        navigation.push(context, AppRoute.homeTab.fullPath, reset: true);
         return;
       }
     } catch (err) {
@@ -248,7 +244,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () => navigation.push(context, 'find-pw'),
+        onPressed: () => navigation.push(context, AppRoute.findPw.fullPath),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -274,10 +274,10 @@ class _SignInState extends State<SignIn> {
     }
 
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
         elevation: 0.0,
-        backgroundColor: Theme.of(context).backgroundColor,
+        backgroundColor: Theme.of(context).colorScheme.background,
         iconTheme: IconThemeData(
           color: Theme.of(context).textTheme.displayLarge!.color,
         ),

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -21,39 +21,39 @@ class SignIn extends HookWidget {
     Localization? _localization;
     var _scrollController = useScrollController();
 
-    var _email = useState<String>("").value;
-    var _password = useState<String?>(null).value;
+    var _email = useState<String>("");
+    var _password = useState<String?>(null);
 
-    var _isValidEmail = useState<bool>(false).value;
-    var _isValidPassword = useState<bool>(false).value;
+    var _isValidEmail = useState<bool>(false);
+    var _isValidPassword = useState<bool>(false);
 
-    var _errorEmail = useState<String?>('').value;
-    var _errorPassword = useState<String?>('').value;
+    var _errorEmail = useState<String?>('');
+    var _errorPassword = useState<String?>('');
 
-    var _isSigningIn = useState<bool>(false).value;
-    var _isResendingEmail = useState<bool>(false).value;
+    var _isSigningIn = useState<bool>(false);
+    var _isResendingEmail = useState<bool>(false);
 
     void _signIn() async {
       if (_auth.currentUser != null) {
         _auth.signOut();
       }
 
-      if (!_isValidEmail) {
-        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
+      if (!_isValidEmail.value) {
+        _errorEmail.value = _localization!.trans('NO_VALID_EMAIL');
         return;
       }
 
-      if (!_isValidPassword) {
-        _errorPassword = _localization!.trans('PASSWORD_HINT');
+      if (!_isValidPassword.value) {
+        _errorPassword.value = _localization!.trans('PASSWORD_HINT');
         return;
       }
 
-      _isSigningIn = true;
+      _isSigningIn.value = true;
 
       UserCredential auth;
       try {
         auth = await _auth.signInWithEmailAndPassword(
-            email: _email, password: _password!);
+            email: _email.value, password: _password.value!);
 
         /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
         if (auth.user != null && auth.user!.emailVerified) {
@@ -74,7 +74,7 @@ class SignIn extends HookWidget {
           return;
         }
       } catch (err) {
-        _isSigningIn = false;
+        _isSigningIn.value = false;
         switch (err) {
           // case 'ERROR_INVALID_EMAIL':
           //   setState(() => _errorEmail = _localization!.trans(err.currency));
@@ -107,7 +107,7 @@ class SignIn extends HookWidget {
               Container(
                 margin: EdgeInsets.only(top: 32, bottom: 24),
                 child: Text(
-                  _email,
+                  _email.value,
                   style: TextStyle(
                     fontSize: 24,
                     color: Theme.of(context).secondaryHeaderColor,
@@ -116,15 +116,15 @@ class SignIn extends HookWidget {
               ),
               Button(
                 height: 40,
-                isLoading: _isResendingEmail,
+                isLoading: _isResendingEmail.value,
                 onPress: () async {
-                  _isResendingEmail = true;
+                  _isResendingEmail.value = true;
                   try {
                     await auth.user!.sendEmailVerification();
                   } catch (err) {
                     // print('unknown error occurred. ${err.message}');
                   } finally {
-                    _isResendingEmail = false;
+                    _isResendingEmail.value = false;
                   }
                 },
                 text: _localization!.trans('RESEND_EMAIL'),
@@ -169,25 +169,25 @@ class SignIn extends HookWidget {
         textInputAction: TextInputAction.next,
         textLabel: _localization!.trans('EMAIL'),
         textHint: _localization!.trans('EMAIL_HINT'),
-        hasChecked: _isValidEmail,
+        hasChecked: _isValidEmail.value,
         hintStyle: TextStyle(color: Theme.of(context).hintColor),
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            _isValidEmail = true;
-            _errorEmail = null;
-            _email = str;
+            _isValidEmail.value = true;
+            _errorEmail.value = null;
+            _email.value = str;
           } else {
-            _isValidEmail = false;
-            _email = str;
+            _isValidEmail.value = false;
+            _email.value = str;
           }
         },
-        errorText: _errorEmail,
+        errorText: _errorEmail.value,
         onSubmitted: (String str) => _signIn(),
       );
     }
 
     Widget renderPasswordField() {
-      bool isValidPassword = _password != null && _password!.length > 0;
+      bool isValidPassword = _password != null && _password.value!.length > 0;
 
       return EditText(
         key: Key('password'),
@@ -199,15 +199,15 @@ class SignIn extends HookWidget {
         hasChecked: isValidPassword,
         onChanged: (String str) {
           if (isValidPassword) {
-            _isValidPassword = true;
-            _errorPassword = null;
-            _password = str;
+            _isValidPassword.value = true;
+            _errorPassword.value = null;
+            _password.value = str;
           } else {
-            _isValidPassword = false;
-            _password = str;
+            _isValidPassword.value = false;
+            _password.value = str;
           }
         },
-        errorText: _errorPassword,
+        errorText: _errorPassword.value,
         onSubmitted: (String str) => _signIn(),
       );
     }
@@ -216,7 +216,7 @@ class SignIn extends HookWidget {
       return Button(
         key: Key('sign-in-button'),
         onPress: _signIn,
-        isLoading: _isSigningIn,
+        isLoading: _isSigningIn.value,
         margin: EdgeInsets.only(top: 28.0, bottom: 8.0),
         textStyle: TextStyle(
           color: Colors.white,

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -68,11 +68,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          navigation.push(context, AppRoute.mainEmpty.fullPath, reset: true);
+          navigation.push(context, AppRoute.mainEmpty.path, reset: true);
           return;
         }
 
-        navigation.push(context, AppRoute.homeTab.fullPath, reset: true);
+        navigation.push(context, AppRoute.homeTab.path, reset: true);
         return;
       }
     } catch (err) {
@@ -244,7 +244,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () => navigation.push(context, AppRoute.findPw.fullPath),
+        onPressed: () => navigation.push(context, AppRoute.findPw.path),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -72,11 +72,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          navigation.push(context, MainEmpty.name, reset: true);
+          navigation.push(context, 'main-empty', reset: true);
           return;
         }
 
-        navigation.push(context, HomeTab.name, reset: true);
+        navigation.push(context, 'home-tab', reset: true);
         return;
       }
     } catch (err) {
@@ -248,7 +248,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () => navigation.push(context, FindPw.name),
+        onPressed: () => navigation.push(context, 'find-pw'),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -4,10 +4,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wecount/navigations/home_tab.dart';
 import 'package:wecount/screens/find_pw.dart';
 import 'package:wecount/screens/main_empty.dart';
+import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/widgets/edit_text.dart' show EditText;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/validator.dart' show Validator;
 
@@ -15,7 +15,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
 class SignIn extends StatefulWidget {
-  static const String name = '/sign_in';
+  static const String name = '/sign-in';
 
   SignIn({Key? key}) : super(key: key);
 
@@ -72,13 +72,11 @@ class _SignInState extends State<SignIn> {
         var ledgers = snapshots.docs;
 
         if (ledgers.length == 0) {
-          General.instance
-              .navigateScreenNamed(context, MainEmpty.name, reset: true);
+          navigation.push(context, MainEmpty.name, reset: true);
           return;
         }
 
-        General.instance
-            .navigateScreenNamed(context, HomeTab.name, reset: true);
+        navigation.push(context, HomeTab.name, reset: true);
         return;
       }
     } catch (err) {
@@ -105,7 +103,7 @@ class _SignInState extends State<SignIn> {
     }
 
     if (auth.user != null && !auth.user!.emailVerified) {
-      General.instance.showSingleDialog(
+      navigation.showSingleDialog(
         context,
         title: Text(_localization!.trans('ERROR')!),
         content: Column(
@@ -250,8 +248,7 @@ class _SignInState extends State<SignIn> {
 
     Widget renderFindPw() {
       return TextButton(
-        onPressed: () =>
-            General.instance.navigateScreenNamed(context, FindPw.name),
+        onPressed: () => navigation.push(context, FindPw.name),
         child: RichText(
           text: TextSpan(
             text: '${_localization!.trans('DID_YOU_FORGOT_PASSWORD')}?',

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -26,17 +26,17 @@ class SignUp extends HookWidget {
     String? _displayName;
     String? _name;
 
-    var _errorEmail = useState<String?>(null).value;
-    var _errorPassword = useState<String?>(null).value;
-    var _errorPasswordConfirm = useState<String?>(null).value;
-    var _errorDisplayName = useState<String?>(null).value;
-    var _errorName = useState<String?>(null).value;
+    var _errorEmail = useState<String?>(null);
+    var _errorPassword = useState<String?>(null);
+    var _errorPasswordConfirm = useState<String?>(null);
+    var _errorDisplayName = useState<String?>(null);
+    var _errorName = useState<String?>(null);
 
-    var _isValidEmail = useState<bool>(false).value;
-    var _isValidPassword = useState<bool>(false).value;
-    var _isValidDisplayName = useState<bool>(false).value;
-    var _isValidName = useState<bool>(false).value;
-    var _isRegistering = useState<bool>(false).value;
+    var _isValidEmail = useState<bool>(false);
+    var _isValidPassword = useState<bool>(false);
+    var _isValidDisplayName = useState<bool>(false);
+    var _isValidName = useState<bool>(false);
+    var _isRegistering = useState<bool>(false);
 
     void _signUp() async {
       if (_email == null ||
@@ -47,32 +47,33 @@ class SignUp extends HookWidget {
         return;
       }
 
-      if (!_isValidEmail) {
-        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
+      if (!_isValidEmail.value) {
+        _errorEmail.value = _localization!.trans('NO_VALID_EMAIL');
         return;
       }
 
-      if (!_isValidPassword) {
-        _errorPassword = _localization!.trans('PASSWORD_HINT');
+      if (!_isValidPassword.value) {
+        _errorPassword.value = _localization!.trans('PASSWORD_HINT');
         return;
       }
 
       if (_passwordConfirm != _password) {
-        _errorPasswordConfirm = _localization!.trans('PASSWORD_CONFIRM_HINT');
+        _errorPasswordConfirm.value =
+            _localization!.trans('PASSWORD_CONFIRM_HINT');
         return;
       }
 
-      if (!_isValidDisplayName) {
-        _errorDisplayName = _localization!.trans('DISPLAY_NAME_HINT');
+      if (!_isValidDisplayName.value) {
+        _errorDisplayName.value = _localization!.trans('DISPLAY_NAME_HINT');
         return;
       }
 
-      if (!_isValidName) {
-        _errorName = _localization!.trans('NAME_HINT');
+      if (!_isValidName.value) {
+        _errorName.value = _localization!.trans('NAME_HINT');
         return;
       }
 
-      _isRegistering = true;
+      _isRegistering.value = true;
 
       try {
         final User? user = (await _auth.createUserWithEmailAndPassword(
@@ -129,7 +130,7 @@ class SignUp extends HookWidget {
           ),
         );
       } finally {
-        _isRegistering = false;
+        _isRegistering.value = false;
       }
     }
 
@@ -155,17 +156,17 @@ class SignUp extends HookWidget {
         textHint: _localization!.trans('EMAIL_HINT'),
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidEmail,
+        hasChecked: _isValidEmail.value,
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            _isValidEmail = true;
-            _errorEmail = null;
+            _isValidEmail.value = true;
+            _errorEmail.value = null;
           } else {
-            _isValidEmail = false;
+            _isValidEmail.value = false;
           }
           _email = str;
         },
-        errorText: _errorEmail,
+        errorText: _errorEmail.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -180,17 +181,17 @@ class SignUp extends HookWidget {
         isSecret: true,
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidPassword,
+        hasChecked: _isValidPassword.value,
         onChanged: (String str) {
           if (Validator.instance.validatePassword(str)) {
-            _isValidPassword = true;
-            _errorPassword = null;
+            _isValidPassword.value = true;
+            _errorPassword.value = null;
           } else {
-            _isValidPassword = false;
+            _isValidPassword.value = false;
           }
           _password = str;
         },
-        errorText: _errorPassword,
+        errorText: _errorPassword.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -211,11 +212,11 @@ class SignUp extends HookWidget {
         onChanged: (String str) {
           _passwordConfirm = str;
           if (str == _password) {
-            _errorPasswordConfirm = null;
+            _errorPasswordConfirm.value = null;
           }
           ;
         },
-        errorText: _errorPasswordConfirm,
+        errorText: _errorPasswordConfirm.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -229,17 +230,17 @@ class SignUp extends HookWidget {
         textHint: _localization!.trans('DISPLAY_NAME_HINT'),
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidDisplayName,
+        hasChecked: _isValidDisplayName.value,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            _isValidDisplayName = true;
-            _errorDisplayName = null;
+            _isValidDisplayName.value = true;
+            _errorDisplayName.value = null;
           } else {
-            _isValidDisplayName = false;
+            _isValidDisplayName.value = false;
           }
           _displayName = str;
         },
-        errorText: _errorDisplayName,
+        errorText: _errorDisplayName.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -253,17 +254,17 @@ class SignUp extends HookWidget {
         textHint: _localization!.trans('NAME_HINT'),
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidName,
+        hasChecked: _isValidName.value,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            _isValidName = true;
-            _errorName = null;
+            _isValidName.value = true;
+            _errorName.value = null;
           } else {
-            _isValidName = false;
+            _isValidName.value = false;
           }
           _name = str;
         },
-        errorText: _errorName,
+        errorText: _errorName.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -271,7 +272,7 @@ class SignUp extends HookWidget {
     Widget renderSignUpButton() {
       return Button(
         key: Key('button-sign-up'),
-        isLoading: _isRegistering,
+        isLoading: _isRegistering.value,
         onPress: () => _signUp(),
         margin: EdgeInsets.only(top: 36.0, bottom: 48.0),
         textStyle: TextStyle(

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -13,9 +13,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
 class SignUp extends StatefulWidget {
-  static const String name = '/sign-up';
-
-  SignUp({Key? key}) : super(key: key);
+  const SignUp({Key? key}) : super(key: key);
 
   @override
   _SignUpState createState() => _SignUpState();

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/edit_text.dart' show EditText;
@@ -12,133 +13,126 @@ import 'package:wecount/utils/asset.dart' as Asset;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
-class SignUp extends StatefulWidget {
+class SignUp extends HookWidget {
   const SignUp({Key? key}) : super(key: key);
 
   @override
-  _SignUpState createState() => _SignUpState();
-}
+  Widget build(BuildContext context) {
+    Localization? _localization;
 
-class _SignUpState extends State<SignUp> {
-  Localization? _localization;
+    String? _email;
+    String? _password;
+    String? _passwordConfirm;
+    String? _displayName;
+    String? _name;
 
-  String? _email;
-  String? _password;
-  String? _passwordConfirm;
-  String? _displayName;
-  String? _name;
+    var _errorEmail = useState<String?>(null).value;
+    var _errorPassword = useState<String?>(null).value;
+    var _errorPasswordConfirm = useState<String?>(null).value;
+    var _errorDisplayName = useState<String?>(null).value;
+    var _errorName = useState<String?>(null).value;
 
-  String? _errorEmail;
-  String? _errorPassword;
-  String? _errorPasswordConfirm;
-  String? _errorDisplayName;
-  String? _errorName;
+    var _isValidEmail = useState<bool>(false).value;
+    var _isValidPassword = useState<bool>(false).value;
+    var _isValidDisplayName = useState<bool>(false).value;
+    var _isValidName = useState<bool>(false).value;
+    var _isRegistering = useState<bool>(false).value;
 
-  bool _isValidEmail = false;
-  bool _isValidPassword = false;
-  bool _isValidDisplayName = false;
-  bool _isValidName = false;
-  bool _isRegistering = false;
+    void _signUp() async {
+      if (_email == null ||
+          _password == null ||
+          _passwordConfirm == null ||
+          _displayName == null ||
+          _name == null) {
+        return;
+      }
 
-  void _signUp() async {
-    if (_email == null ||
-        _password == null ||
-        _passwordConfirm == null ||
-        _displayName == null ||
-        _name == null) {
-      return;
-    }
+      if (!_isValidEmail) {
+        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
+        return;
+      }
 
-    if (!_isValidEmail) {
-      setState(() => _errorEmail = _localization!.trans('NO_VALID_EMAIL'));
-      return;
-    }
+      if (!_isValidPassword) {
+        _errorPassword = _localization!.trans('PASSWORD_HINT');
+        return;
+      }
 
-    if (!_isValidPassword) {
-      setState(() => _errorPassword = _localization!.trans('PASSWORD_HINT'));
-      return;
-    }
+      if (_passwordConfirm != _password) {
+        _errorPasswordConfirm = _localization!.trans('PASSWORD_CONFIRM_HINT');
+        return;
+      }
 
-    if (_passwordConfirm != _password) {
-      setState(() => _errorPasswordConfirm =
-          _localization!.trans('PASSWORD_CONFIRM_HINT'));
-      return;
-    }
+      if (!_isValidDisplayName) {
+        _errorDisplayName = _localization!.trans('DISPLAY_NAME_HINT');
+        return;
+      }
 
-    if (!_isValidDisplayName) {
-      setState(
-          () => _errorDisplayName = _localization!.trans('DISPLAY_NAME_HINT'));
-      return;
-    }
+      if (!_isValidName) {
+        _errorName = _localization!.trans('NAME_HINT');
+        return;
+      }
 
-    if (!_isValidName) {
-      setState(() => _errorName = _localization!.trans('NAME_HINT'));
-      return;
-    }
+      _isRegistering = true;
 
-    setState(() => _isRegistering = true);
+      try {
+        final User? user = (await _auth.createUserWithEmailAndPassword(
+          email: _email!,
+          password: _password!,
+        ))
+            .user;
 
-    try {
-      final User? user = (await _auth.createUserWithEmailAndPassword(
-        email: _email!,
-        password: _password!,
-      ))
-          .user;
+        if (user != null) {
+          await user.sendEmailVerification();
+          await firestore.collection('users').doc(user.uid).set({
+            'email': _email,
+            'displayName': _displayName,
+            'name': _name,
+            'createdAt': FieldValue.serverTimestamp(),
+            'updatedAt': FieldValue.serverTimestamp(),
+            'deletedAt': null,
+          });
 
-      if (user != null) {
-        await user.sendEmailVerification();
-        await firestore.collection('users').doc(user.uid).set({
-          'email': _email,
-          'displayName': _displayName,
-          'name': _name,
-          'createdAt': FieldValue.serverTimestamp(),
-          'updatedAt': FieldValue.serverTimestamp(),
-          'deletedAt': null,
-        });
+          user.updateDisplayName(_displayName);
 
-        user.updateDisplayName(_displayName);
+          return navigation.showSingleDialog(
+            context,
+            title: Text(
+              _localization!.trans('SIGN_UP_SUCCESS_TITLE')!,
+              style: TextStyle(
+                  color: Theme.of(context).dialogTheme.titleTextStyle!.color),
+            ),
+            content: Text(
+              _localization!.trans('SIGN_UP_SUCCESS_CONTENT')!,
+              style: TextStyle(
+                  color: Theme.of(context).dialogTheme.contentTextStyle!.color),
+            ),
+            onPress: () {
+              _auth.signOut();
+              Navigator.of(context).pop();
+            },
+          );
+        }
 
-        return navigation.showSingleDialog(
+        throw Error();
+      } catch (err) {
+        navigation.showSingleDialog(
           context,
           title: Text(
-            _localization!.trans('SIGN_UP_SUCCESS_TITLE')!,
+            _localization!.trans('SIGN_UP_ERROR_TITLE')!,
             style: TextStyle(
                 color: Theme.of(context).dialogTheme.titleTextStyle!.color),
           ),
           content: Text(
-            _localization!.trans('SIGN_UP_SUCCESS_CONTENT')!,
+            _localization!.trans('SIGN_UP_ERROR_CONTENT')!,
             style: TextStyle(
                 color: Theme.of(context).dialogTheme.contentTextStyle!.color),
           ),
-          onPress: () {
-            _auth.signOut();
-            Navigator.of(context).pop();
-          },
         );
+      } finally {
+        _isRegistering = false;
       }
-
-      throw Error();
-    } catch (err) {
-      navigation.showSingleDialog(
-        context,
-        title: Text(
-          _localization!.trans('SIGN_UP_ERROR_TITLE')!,
-          style: TextStyle(
-              color: Theme.of(context).dialogTheme.titleTextStyle!.color),
-        ),
-        content: Text(
-          _localization!.trans('SIGN_UP_ERROR_CONTENT')!,
-          style: TextStyle(
-              color: Theme.of(context).dialogTheme.contentTextStyle!.color),
-        ),
-      );
-    } finally {
-      setState(() => _isRegistering = false);
     }
-  }
 
-  @override
-  Widget build(BuildContext context) {
     _localization = Localization.of(context);
 
     Widget renderSignUpText() {
@@ -164,12 +158,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidEmail,
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            setState(() {
-              _isValidEmail = true;
-              _errorEmail = null;
-            });
+            _isValidEmail = true;
+            _errorEmail = null;
           } else {
-            setState(() => _isValidEmail = false);
+            _isValidEmail = false;
           }
           _email = str;
         },
@@ -191,12 +183,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidPassword,
         onChanged: (String str) {
           if (Validator.instance.validatePassword(str)) {
-            setState(() {
-              _isValidPassword = true;
-              _errorPassword = null;
-            });
+            _isValidPassword = true;
+            _errorPassword = null;
           } else {
-            setState(() => _isValidPassword = false);
+            _isValidPassword = false;
           }
           _password = str;
         },
@@ -218,12 +208,13 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _passwordConfirm != null &&
             _passwordConfirm != '' &&
             _passwordConfirm == _password,
-        onChanged: (String str) => setState(() {
+        onChanged: (String str) {
           _passwordConfirm = str;
           if (str == _password) {
             _errorPasswordConfirm = null;
           }
-        }),
+          ;
+        },
         errorText: _errorPasswordConfirm,
         onSubmitted: (String str) => _signUp(),
       );
@@ -241,12 +232,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidDisplayName,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            setState(() {
-              _isValidDisplayName = true;
-              _errorDisplayName = null;
-            });
+            _isValidDisplayName = true;
+            _errorDisplayName = null;
           } else {
-            setState(() => _isValidDisplayName = false);
+            _isValidDisplayName = false;
           }
           _displayName = str;
         },
@@ -267,12 +256,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidName,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            setState(() {
-              _isValidName = true;
-              _errorName = null;
-            });
+            _isValidName = true;
+            _errorName = null;
           } else {
-            setState(() => _isValidName = false);
+            _isValidName = false;
           }
           _name = str;
         },

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:wecount/utils/navigation.dart';
 
-import 'package:wecount/utils/general.dart' show General;
 import 'package:wecount/widgets/edit_text.dart' show EditText;
 import 'package:wecount/widgets/button.dart' show Button;
 import 'package:wecount/utils/localization.dart' show Localization;
@@ -13,7 +13,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
 class SignUp extends StatefulWidget {
-  static const String name = '/sign_up';
+  static const String name = '/sign-up';
 
   SignUp({Key? key}) : super(key: key);
 
@@ -100,7 +100,7 @@ class _SignUpState extends State<SignUp> {
 
         user.updateDisplayName(_displayName);
 
-        return General.instance.showSingleDialog(
+        return navigation.showSingleDialog(
           context,
           title: Text(
             _localization!.trans('SIGN_UP_SUCCESS_TITLE')!,
@@ -121,7 +121,7 @@ class _SignUpState extends State<SignUp> {
 
       throw Error();
     } catch (err) {
-      General.instance.showSingleDialog(
+      navigation.showSingleDialog(
         context,
         title: Text(
           _localization!.trans('SIGN_UP_ERROR_TITLE')!,

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -19,7 +19,7 @@ class _SplashState extends State<Splash> {
   Timer? _timer;
 
   Future<void> navigateRoute() async {
-    String initialRoute = AppRoute.tutorial.fullPath;
+    String initialRoute = AppRoute.tutorial.path;
 
     _navigationTimer = Timer(Duration(milliseconds: 1500), () {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:wecount/screens/tutorial.dart';
 
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
+import 'package:wecount/utils/navigation.dart';
 
 class Splash extends StatefulWidget {
   static const String name = '/splash';
@@ -26,7 +26,7 @@ class _SplashState extends State<Splash> {
     _navigationTimer = Timer(Duration(milliseconds: 1500), () {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
           overlays: SystemUiOverlay.values);
-      General.instance.navigateScreenNamed(context, initialRoute, reset: true);
+      navigation.push(context, initialRoute, reset: true);
     });
   }
 

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -1,59 +1,49 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:wecount/screens/tutorial.dart';
 
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 
-class Splash extends StatefulWidget {
+class Splash extends HookWidget {
   const Splash({Key? key}) : super(key: key);
 
   @override
-  _SplashState createState() => _SplashState();
-}
-
-class _SplashState extends State<Splash> {
-  bool _visible = false;
-  Timer? _navigationTimer;
-  Timer? _timer;
-
-  Future<void> navigateRoute() async {
-    String initialRoute = AppRoute.tutorial.path;
-
-    _navigationTimer = Timer(Duration(milliseconds: 1500), () {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
-          overlays: SystemUiOverlay.values);
-      navigation.push(context, initialRoute, reset: true);
-    });
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    _timer = Timer(Duration(milliseconds: 1000), () {
-      setState(() {
-        this._visible = true;
-      });
-    });
-    SystemChrome.setEnabledSystemUIOverlays([]);
-    this.navigateRoute();
-  }
-
-  @override
-  void dispose() {
-    if (_timer != null) {
-      _timer!.cancel();
-    }
-    if (_navigationTimer != null) {
-      _navigationTimer!.cancel();
-    }
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    bool _visible = false;
+    Timer? _navigationTimer;
+    Timer? _timer;
+
+    Future<void> navigateRoute() async {
+      String initialRoute = AppRoute.tutorial.path;
+
+      _navigationTimer = Timer(Duration(milliseconds: 1500), () {
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+            overlays: SystemUiOverlay.values);
+        navigation.push(context, initialRoute, reset: true);
+      });
+    }
+
+    useEffect(() {
+      _timer = Timer(Duration(milliseconds: 1000), () {
+        _visible = true;
+      });
+      SystemChrome.setEnabledSystemUIOverlays([]);
+
+      navigateRoute();
+      return () {
+        if (_timer != null) {
+          _timer!.cancel();
+        }
+        if (_navigationTimer != null) {
+          _navigationTimer!.cancel();
+        }
+      };
+    }, []);
+
     return Scaffold(
       primary: true,
       body: SafeArea(

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -1,15 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:wecount/screens/tutorial.dart';
 
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 class Splash extends StatefulWidget {
-  static const String name = '/splash';
-
-  Splash({Key? key}) : super(key: key);
+  const Splash({Key? key}) : super(key: key);
 
   @override
   _SplashState createState() => _SplashState();
@@ -21,7 +19,7 @@ class _SplashState extends State<Splash> {
   Timer? _timer;
 
   Future<void> navigateRoute() async {
-    String initialRoute = Tutorial.name;
+    String initialRoute = AppRoute.tutorial.fullPath;
 
     _navigationTimer = Timer(Duration(milliseconds: 1500), () {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,

--- a/lib/screens/terms.dart
+++ b/lib/screens/terms.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 
 class Terms extends StatefulWidget {
-  static const String name = '/terms';
-
-  Terms({Key? key}) : super(key: key);
+  const Terms({Key? key}) : super(key: key);
 
   @override
   _TermsState createState() => _TermsState();

--- a/lib/screens/terms.dart
+++ b/lib/screens/terms.dart
@@ -1,13 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
-class Terms extends StatefulWidget {
+class Terms extends HookWidget {
   const Terms({Key? key}) : super(key: key);
 
-  @override
-  _TermsState createState() => _TermsState();
-}
-
-class _TermsState extends State<Terms> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -1,36 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:wecount/screens/intro.dart';
 
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/routes.dart';
 
-class Tutorial extends StatefulWidget {
+class Tutorial extends HookWidget {
   const Tutorial({Key? key}) : super(key: key);
 
   @override
-  _TutorialState createState() => _TutorialState();
-}
-
-class _TutorialState extends State<Tutorial> {
-  final int pageCnt = 2; // 3
-  int _currentPage = 0;
-  var _pageController = PageController(
-    initialPage: 0,
-  );
-  void onNextPressed() {
-    if (_currentPage == pageCnt) {
-      Navigator.pushNamedAndRemoveUntil(
-          context, AppRoute.intro.fullPath, (_) => false);
-      return;
-    }
-    _pageController.nextPage(
-      duration: Duration(milliseconds: 300),
-      curve: Curves.easeIn,
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final int pageCnt = 2; // 3
+    var _currentPage = useState<int>(0).value;
+    var _pageController = PageController(
+      initialPage: 0,
+    );
+    void onNextPressed() {
+      if (_currentPage == pageCnt) {
+        Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
+        return;
+      }
+      _pageController.nextPage(
+        duration: Duration(milliseconds: 300),
+        curve: Curves.easeIn,
+      );
+    }
+
     var _localization = Localization.of(context)!;
 
     Widget renderPage({
@@ -152,9 +148,7 @@ class _TutorialState extends State<Tutorial> {
               Expanded(
                 child: PageView(
                   onPageChanged: (int page) {
-                    setState(() {
-                      _currentPage = page;
-                    });
+                    _currentPage = page;
                   },
                   controller: _pageController,
                   scrollDirection: Axis.horizontal,

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:wecount/screens/intro.dart';
 
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
+import 'package:wecount/utils/routes.dart';
 
 class Tutorial extends StatefulWidget {
-  static const String name = '/tutorial';
+  const Tutorial({Key? key}) : super(key: key);
 
   @override
   _TutorialState createState() => _TutorialState();
@@ -19,7 +19,8 @@ class _TutorialState extends State<Tutorial> {
   );
   void onNextPressed() {
     if (_currentPage == pageCnt) {
-      Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
+      Navigator.pushNamedAndRemoveUntil(
+          context, AppRoute.intro.fullPath, (_) => false);
       return;
     }
     _pageController.nextPage(

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -19,7 +19,7 @@ class _TutorialState extends State<Tutorial> {
   );
   void onNextPressed() {
     if (_currentPage == pageCnt) {
-      Navigator.pushNamedAndRemoveUntil(context, Intro.name, (_) => false);
+      Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
       return;
     }
     _pageController.nextPage(

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -17,8 +17,8 @@ class Tutorial extends HookWidget {
       initialPage: 0,
     );
     void onNextPressed() {
-      if (_currentPage == pageCnt) {
-        Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
+      if (_currentPage.value == pageCnt) {
+        Navigator.pushNamedAndRemoveUntil(context, '/intro', (_) => false);
         return;
       }
       _pageController.nextPage(

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -12,7 +12,7 @@ class Tutorial extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final int pageCnt = 2; // 3
-    var _currentPage = useState<int>(0).value;
+    var _currentPage = useState<int>(0);
     var _pageController = PageController(
       initialPage: 0,
     );
@@ -148,7 +148,7 @@ class Tutorial extends HookWidget {
               Expanded(
                 child: PageView(
                   onPageChanged: (int page) {
-                    _currentPage = page;
+                    _currentPage.value = page;
                   },
                   controller: _pageController,
                   scrollDirection: Axis.horizontal,

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -173,11 +173,11 @@ class DatabaseService {
 
     await FirebaseFirestore.instance
         .collection('users')
-        .doc(_profile!.uid)
+        .doc(_profile?.uid)
         .set({
-      'displayName': _profile.displayName,
-      'phoneNumber': _profile.phoneNumber,
-      'statusMsg': _profile.statusMsg,
+      'displayName': _profile?.displayName,
+      'phoneNumber': _profile?.phoneNumber,
+      'statusMsg': _profile?.statusMsg,
     }, SetOptions(merge: true));
 
     return true;

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -8,6 +8,7 @@ import 'package:wecount/models/ledger.dart';
 import 'package:wecount/models/user.dart' as UserM;
 import 'package:wecount/services/storage.dart';
 import 'package:wecount/utils/db_helper.dart';
+import 'package:wecount/utils/logger.dart';
 
 class DatabaseService {
   final FirebaseFirestore _db = FirebaseFirestore.instance;

--- a/lib/utils/db_helper.dart
+++ b/lib/utils/db_helper.dart
@@ -164,9 +164,11 @@ class DBHelper {
     return db.delete('categories', where: "iconId = ?", whereArgs: [iconId]);
   }
 
-  bool isExistFiled(DocumentSnapshot doc, String filedName) {
-    Map data = doc.data() as Map;
-
-    return data[filedName] != null;
+  bool isExistFiled(doc, String filedName) {
+    if (doc.data() != null) {
+      Map data = doc.data();
+      return data[filedName] != null;
+    }
+    return false;
   }
 }

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -23,13 +23,13 @@ class _Navigation {
     if (reset) {
       return Navigator.pushNamedAndRemoveUntil(
         context,
-        '$routeName',
-        ModalRoute.withName('$routeName'),
+        '/$routeName',
+        ModalRoute.withName('/$routeName'),
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
   }
 
   Future navigate(
@@ -40,14 +40,14 @@ class _Navigation {
   }) {
     if (reset) {
       return Navigator.of(context).pushNamedAndRemoveUntil(
-        '$routeName',
+        '/$routeName',
         (route) =>
             route.isCurrent && route.settings.name == routeName ? false : true,
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
   }
 
   void pop<T extends String>(
@@ -64,7 +64,7 @@ class _Navigation {
     return Navigator.popUntil(
       context,
       (route) {
-        return route.settings.name == '$routeName';
+        return route.settings.name == '/$routeName';
       },
     );
   }

--- a/lib/utils/navigation.dart
+++ b/lib/utils/navigation.dart
@@ -23,13 +23,13 @@ class _Navigation {
     if (reset) {
       return Navigator.pushNamedAndRemoveUntil(
         context,
-        '/$routeName',
-        ModalRoute.withName('/$routeName'),
+        '$routeName',
+        ModalRoute.withName('$routeName'),
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
   }
 
   Future navigate(
@@ -40,14 +40,14 @@ class _Navigation {
   }) {
     if (reset) {
       return Navigator.of(context).pushNamedAndRemoveUntil(
-        '/$routeName',
+        '$routeName',
         (route) =>
             route.isCurrent && route.settings.name == routeName ? false : true,
         arguments: arguments,
       );
     }
 
-    return Navigator.of(context).pushNamed('/$routeName', arguments: arguments);
+    return Navigator.of(context).pushNamed('$routeName', arguments: arguments);
   }
 
   void pop<T extends String>(
@@ -64,7 +64,7 @@ class _Navigation {
     return Navigator.popUntil(
       context,
       (route) {
-        return route.settings.name == '/$routeName';
+        return route.settings.name == '$routeName';
       },
     );
   }

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -115,7 +115,8 @@ final routes = {
   AppRoute.lockRegister.fullPath: (context) => const LockRegister(),
   AppRoute.lockAuth.fullPath: (context) => const LockAuth(),
   AppRoute.locationView.fullPath: (context) => const LocationView(),
-  AppRoute.ledgerEdit.fullPath: (context) => const LedgerEdit()
+  AppRoute.ledgerEdit.fullPath: (context) => const LedgerEdit(),
+  AppRoute.settingCurrency.fullPath: (context) => const SettingCurrency()
 };
 
 MaterialPageRoute onGenerateRoute(RouteSettings settings) {

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -128,14 +128,21 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
   }
 
   if (settings.name == LedgerEdit.name) {
-    final LedgerEditArguments args = settings.arguments as LedgerEditArguments;
+    if (settings.arguments == null) {
+      return MaterialPageRoute(builder: (context) {
+        return LedgerEdit();
+      });
+    } else {
+      final LedgerEditArguments args =
+          settings.arguments as LedgerEditArguments;
 
-    return MaterialPageRoute(builder: (context) {
-      return LedgerEdit(
-        ledger: args.ledger,
-        mode: args.mode,
-      );
-    });
+      return MaterialPageRoute(builder: (context) {
+        return LedgerEdit(
+          ledger: args.ledger,
+          mode: args.mode,
+        );
+      });
+    }
   }
 
   throw 'Route not found: ${settings.name}';

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/navigations/home_tab.dart';
 import 'package:wecount/screens/find_pw.dart';
@@ -7,10 +8,14 @@ import 'package:wecount/screens/ledger_item_edit.dart';
 import 'package:wecount/screens/ledger_view.dart';
 import 'package:wecount/screens/ledgers.dart';
 import 'package:wecount/screens/line_graph.dart';
+import 'package:wecount/screens/location_view.dart';
 import 'package:wecount/screens/lock_auth.dart';
 import 'package:wecount/screens/lock_register.dart';
 import 'package:wecount/screens/main_empty.dart';
+import 'package:wecount/screens/members.dart';
+import 'package:wecount/screens/photo_detail.dart';
 import 'package:wecount/screens/profile_my.dart';
+import 'package:wecount/screens/profile_peer.dart';
 import 'package:wecount/screens/setting.dart';
 import 'package:wecount/screens/setting_announcement.dart';
 import 'package:wecount/screens/setting_currency.dart';
@@ -35,8 +40,6 @@ final routes = {
   MainEmpty.name: (context) => MainEmpty(),
   HomeTab.name: (context) => HomeTab(),
   Ledgers.name: (context) => Ledgers(),
-  LedgerEdit.name: (context) => LedgerEdit(),
-  LedgerView.name: (context) => LedgerView(),
   Terms.name: (context) => Terms(),
   ProfileMy.name: (context) => ProfileMy(),
   Setting.name: (context) => Setting(),
@@ -45,9 +48,95 @@ final routes = {
   SettingFAQ.name: (context) => SettingFAQ(),
   SettingNotification.name: (context) => SettingNotification(),
   LedgerItemEdit.name: (context) => LedgerItemEdit(),
-  SettingCurrency.name: (context) => SettingCurrency(),
   SettingExcel.name: (context) => SettingExcel(),
   LockRegister.name: (context) => LockRegister(),
   LockAuth.name: (context) => LockAuth(),
-  LineGraph.name: (context) => LineGraph(),
+  LocationView.name: (context) => LocationView()
 };
+
+MaterialPageRoute onGenerateRoute(RouteSettings settings) {
+  // If you push the PassArguments route
+  if (settings.name == PhotoDetail.name) {
+    final PhotoDetailArguments args =
+        settings.arguments as PhotoDetailArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return PhotoDetail(
+        canShare: args.canShare,
+        onPressDelete: args.onPressDelete,
+        onPressDownload: args.onPressDownload,
+        onPressShare: args.onPressShare,
+        photo: args.photo,
+        photoUrl: args.photoUrl,
+      );
+    });
+  }
+
+  if (settings.name == LineGraph.name) {
+    final LineGraphArguments args = settings.arguments as LineGraphArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return LineGraph(
+        title: args.title,
+        year: args.year,
+        price: args.price!,
+      );
+    });
+  }
+
+  if (settings.name == Members.name) {
+    final MembersArguments args = settings.arguments as MembersArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return Members(
+        ledger: args.ledger,
+      );
+    });
+  }
+
+  if (settings.name == SettingCurrency.name) {
+    final SettingCurrencyArguments args =
+        settings.arguments as SettingCurrencyArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return SettingCurrency(
+        selectedCurrency: args.selectedCurrency,
+        title: args.title,
+      );
+    });
+  }
+
+  if (settings.name == ProfilePeer.name) {
+    final ProfilePeerArguments args =
+        settings.arguments as ProfilePeerArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return ProfilePeer(
+        user: args.user,
+      );
+    });
+  }
+
+  if (settings.name == LedgerView.name) {
+    final LedgerViewArguments args = settings.arguments as LedgerViewArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return LedgerView(
+        ledger: args.ledger,
+      );
+    });
+  }
+
+  if (settings.name == LedgerEdit.name) {
+    final LedgerEditArguments args = settings.arguments as LedgerEditArguments;
+
+    return MaterialPageRoute(builder: (context) {
+      return LedgerEdit(
+        ledger: args.ledger,
+        mode: args.mode,
+      );
+    });
+  }
+
+  throw 'Route not found: ${settings.name}';
+}

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:wecount/navigations/auth_switch.dart';
 import 'package:wecount/navigations/home_tab.dart';
@@ -29,34 +30,96 @@ import 'package:wecount/screens/splash.dart';
 import 'package:wecount/screens/terms.dart';
 import 'package:wecount/screens/tutorial.dart';
 
+enum AppRoute {
+  authSwitch,
+  splash,
+  tutorial,
+  intro,
+  signIn,
+  signUp,
+  findPw,
+  mainEmpty,
+  homeTab,
+  ledgers,
+  terms,
+  profileMy,
+  setting,
+  settingAnnouncement,
+  settingOpinion,
+  settingFAQ,
+  settingNotification,
+  ledgerItemEdit,
+  settingExcel,
+  lockRegister,
+  lockAuth,
+  locationView,
+  photoDetail,
+  lineGraph,
+  members,
+  settingCurrency,
+  profilePeer,
+  ledgerView,
+  ledgerEdit,
+}
+
+extension RouteName on AppRoute {
+  String get name => describeEnum(this);
+
+  bool get isRoot => this == AppRoute.authSwitch;
+
+  /// Convert to `lower-snake-case` format.
+  String get path {
+    if (isRoot) return '';
+
+    RegExp exp = RegExp(r'(?<=[a-z])[A-Z]');
+    String result = name
+        .replaceAllMapped(exp, (Match m) => ('-${m.group(0)}'))
+        .toLowerCase();
+    return result;
+  }
+
+  /// Convert to `lower-snake-case` format with `/`.
+  String get fullPath {
+    if (isRoot) return '/';
+
+    RegExp exp = RegExp(r'(?<=[a-z])[A-Z]');
+    String result = name
+        .replaceAllMapped(exp, (Match m) => ('-${m.group(0)}'))
+        .toLowerCase();
+    return '/$result';
+  }
+}
+
 final routes = {
-  AuthSwitch.name: (context) => AuthSwitch(),
-  Splash.name: (context) => Splash(),
-  Tutorial.name: (context) => Tutorial(),
-  Intro.name: (context) => Intro(),
-  SignIn.name: (context) => SignIn(),
-  SignUp.name: (context) => SignUp(),
-  FindPw.name: (context) => FindPw(),
-  MainEmpty.name: (context) => MainEmpty(),
-  HomeTab.name: (context) => HomeTab(),
-  Ledgers.name: (context) => Ledgers(),
-  Terms.name: (context) => Terms(),
-  ProfileMy.name: (context) => ProfileMy(),
-  Setting.name: (context) => Setting(),
-  SettingAnnouncement.name: (context) => SettingAnnouncement(),
-  SettingOpinion.name: (context) => SettingOpinion(),
-  SettingFAQ.name: (context) => SettingFAQ(),
-  SettingNotification.name: (context) => SettingNotification(),
-  LedgerItemEdit.name: (context) => LedgerItemEdit(),
-  SettingExcel.name: (context) => SettingExcel(),
-  LockRegister.name: (context) => LockRegister(),
-  LockAuth.name: (context) => LockAuth(),
-  LocationView.name: (context) => LocationView()
+  AppRoute.authSwitch.fullPath: (context) => const AuthSwitch(),
+  AppRoute.splash.fullPath: (context) => const Splash(),
+  AppRoute.tutorial.fullPath: (context) => const Tutorial(),
+  AppRoute.intro.fullPath: (context) => const Intro(),
+  AppRoute.signIn.fullPath: (context) => const SignIn(),
+  AppRoute.signUp.fullPath: (context) => const SignIn(),
+  AppRoute.findPw.fullPath: (context) => const FindPw(),
+  AppRoute.mainEmpty.fullPath: (context) => const MainEmpty(),
+  AppRoute.homeTab.fullPath: (context) => const HomeTab(),
+  AppRoute.ledgers.fullPath: (context) => const Ledgers(),
+  AppRoute.terms.fullPath: (context) => const Terms(),
+  AppRoute.profileMy.fullPath: (context) => const ProfileMy(),
+  AppRoute.setting.fullPath: (context) => const Setting(),
+  AppRoute.settingAnnouncement.fullPath: (context) =>
+      const SettingAnnouncement(),
+  AppRoute.settingOpinion.fullPath: (context) => const SettingOpinion(),
+  AppRoute.settingFAQ.fullPath: (context) => const SettingFAQ(),
+  AppRoute.settingNotification.fullPath: (context) =>
+      const SettingNotification(),
+  AppRoute.ledgerItemEdit.fullPath: (context) => const LedgerItemEdit(),
+  AppRoute.settingExcel.fullPath: (context) => const SettingExcel(),
+  AppRoute.lockRegister.fullPath: (context) => const LockRegister(),
+  AppRoute.lockAuth.fullPath: (context) => const LockAuth(),
+  AppRoute.locationView.fullPath: (context) => const LocationView()
 };
 
 MaterialPageRoute onGenerateRoute(RouteSettings settings) {
   // If you push the PassArguments route
-  if (settings.name == PhotoDetail.name) {
+  if (settings.name == AppRoute.photoDetail.fullPath) {
     final PhotoDetailArguments args =
         settings.arguments as PhotoDetailArguments;
 
@@ -72,7 +135,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == LineGraph.name) {
+  if (settings.name == AppRoute.lineGraph.fullPath) {
     final LineGraphArguments args = settings.arguments as LineGraphArguments;
 
     return MaterialPageRoute(builder: (context) {
@@ -84,7 +147,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == Members.name) {
+  if (settings.name == AppRoute.members.fullPath) {
     final MembersArguments args = settings.arguments as MembersArguments;
 
     return MaterialPageRoute(builder: (context) {
@@ -94,7 +157,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == SettingCurrency.name) {
+  if (settings.name == AppRoute.settingCurrency.fullPath) {
     final SettingCurrencyArguments args =
         settings.arguments as SettingCurrencyArguments;
 
@@ -106,7 +169,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == ProfilePeer.name) {
+  if (settings.name == AppRoute.profilePeer.fullPath) {
     final ProfilePeerArguments args =
         settings.arguments as ProfilePeerArguments;
 
@@ -117,7 +180,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == LedgerView.name) {
+  if (settings.name == AppRoute.ledgerView.fullPath) {
     final LedgerViewArguments args = settings.arguments as LedgerViewArguments;
 
     return MaterialPageRoute(builder: (context) {
@@ -127,7 +190,7 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
     });
   }
 
-  if (settings.name == LedgerEdit.name) {
+  if (settings.name == AppRoute.ledgerEdit.fullPath) {
     if (settings.arguments == null) {
       return MaterialPageRoute(builder: (context) {
         return LedgerEdit();

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -96,7 +96,7 @@ final routes = {
   AppRoute.tutorial.fullPath: (context) => const Tutorial(),
   AppRoute.intro.fullPath: (context) => const Intro(),
   AppRoute.signIn.fullPath: (context) => const SignIn(),
-  AppRoute.signUp.fullPath: (context) => const SignIn(),
+  AppRoute.signUp.fullPath: (context) => const SignUp(),
   AppRoute.findPw.fullPath: (context) => const FindPw(),
   AppRoute.mainEmpty.fullPath: (context) => const MainEmpty(),
   AppRoute.homeTab.fullPath: (context) => const HomeTab(),
@@ -114,7 +114,8 @@ final routes = {
   AppRoute.settingExcel.fullPath: (context) => const SettingExcel(),
   AppRoute.lockRegister.fullPath: (context) => const LockRegister(),
   AppRoute.lockAuth.fullPath: (context) => const LockAuth(),
-  AppRoute.locationView.fullPath: (context) => const LocationView()
+  AppRoute.locationView.fullPath: (context) => const LocationView(),
+  AppRoute.ledgerEdit.fullPath: (context) => const LedgerEdit()
 };
 
 MaterialPageRoute onGenerateRoute(RouteSettings settings) {
@@ -191,21 +192,14 @@ MaterialPageRoute onGenerateRoute(RouteSettings settings) {
   }
 
   if (settings.name == AppRoute.ledgerEdit.fullPath) {
-    if (settings.arguments == null) {
-      return MaterialPageRoute(builder: (context) {
-        return LedgerEdit();
-      });
-    } else {
-      final LedgerEditArguments args =
-          settings.arguments as LedgerEditArguments;
+    final LedgerEditArguments args = settings.arguments as LedgerEditArguments;
 
-      return MaterialPageRoute(builder: (context) {
-        return LedgerEdit(
-          ledger: args.ledger,
-          mode: args.mode,
-        );
-      });
-    }
+    return MaterialPageRoute(builder: (context) {
+      return LedgerEdit(
+        ledger: args.ledger,
+        mode: args.mode,
+      );
+    });
   }
 
   throw 'Route not found: ${settings.name}';

--- a/lib/utils/themes.dart
+++ b/lib/utils/themes.dart
@@ -33,6 +33,11 @@ class Themes {
         bodySmall: TextStyle(color: Asset.Colors.light),
         bodyLarge: TextStyle(color: Asset.Colors.dark),
         bodyMedium: TextStyle(color: Asset.Colors.dark),
+        labelLarge: TextStyle(color: Asset.Colors.dark),
+        labelSmall: TextStyle(color: Asset.Colors.dark),
+        titleLarge: TextStyle(color: Asset.Colors.dark),
+        titleMedium: TextStyle(color: Asset.Colors.dark),
+        titleSmall: TextStyle(color: Asset.Colors.dark),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,
@@ -70,6 +75,11 @@ class Themes {
         bodySmall: TextStyle(color: Asset.Colors.dark),
         bodyLarge: TextStyle(color: Asset.Colors.light),
         bodyMedium: TextStyle(color: Asset.Colors.light),
+        labelLarge: TextStyle(color: Asset.Colors.light),
+        labelSmall: TextStyle(color: Asset.Colors.light),
+        titleLarge: TextStyle(color: Asset.Colors.light),
+        titleMedium: TextStyle(color: Asset.Colors.light),
+        titleSmall: TextStyle(color: Asset.Colors.light),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,

--- a/lib/utils/themes.dart
+++ b/lib/utils/themes.dart
@@ -31,6 +31,8 @@ class Themes {
         displayMedium: TextStyle(color: Asset.Colors.mediumGray),
         displaySmall: TextStyle(color: Asset.Colors.paleGray),
         bodySmall: TextStyle(color: Asset.Colors.light),
+        bodyLarge: TextStyle(color: Asset.Colors.dark),
+        bodyMedium: TextStyle(color: Asset.Colors.dark),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,
@@ -66,6 +68,8 @@ class Themes {
         displayMedium: TextStyle(color: Asset.Colors.paleGray),
         displaySmall: TextStyle(color: Asset.Colors.mediumGray),
         bodySmall: TextStyle(color: Asset.Colors.dark),
+        bodyLarge: TextStyle(color: Asset.Colors.light),
+        bodyMedium: TextStyle(color: Asset.Colors.light),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,

--- a/lib/widgets/carousel.dart
+++ b/lib/widgets/carousel.dart
@@ -25,7 +25,7 @@ class Carousel extends HookWidget {
     final List<Photo> picture;
     final double? height;
     final double? viewportFraction;
-    var currentPage = useState<int?>(null).value;
+    var currentPage = useState<int?>(null);
 
     PageController? _controller;
 
@@ -114,7 +114,7 @@ class Carousel extends HookWidget {
 
     useEffect(() {
       _controller = PageController(
-        initialPage: currentPage!,
+        initialPage: currentPage.value!,
         keepPage: false,
         viewportFraction: this.viewportFraction!,
 
@@ -130,7 +130,7 @@ class Carousel extends HookWidget {
       child: PageView.builder(
         itemCount: this.picture.length,
         onPageChanged: (value) {
-          currentPage = value;
+          currentPage.value = value;
         },
         controller: _controller,
         itemBuilder: (context, index) {

--- a/lib/widgets/carousel.dart
+++ b/lib/widgets/carousel.dart
@@ -1,10 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/models/photo.dart' show Photo;
 
-class Carousel extends StatefulWidget {
+class Carousel extends HookWidget {
   final currentPage;
   final List<Photo> picture;
   final double height;
@@ -20,146 +21,122 @@ class Carousel extends StatefulWidget {
   });
 
   @override
-  _CarouselState createState() => _CarouselState(
-        picture,
-        currentPage: this.currentPage,
-        height: this.height,
-        viewportFraction: this.viewportFraction,
-      );
-}
-
-class _CarouselState extends State<Carousel> {
-  final List<Photo> picture;
-  final double? height;
-  final double? viewportFraction;
-  int? currentPage;
-
-  _CarouselState(
-    this.picture, {
-    this.currentPage,
-    this.height,
-    this.viewportFraction,
-  });
-
-  PageController? _controller;
-
-  @override
-  initState() {
-    super.initState();
-    _controller = PageController(
-      initialPage: this.currentPage!,
-      keepPage: false,
-      viewportFraction: this.viewportFraction!,
-
-      /// width percentage
-    );
-  }
-
-  @override
-  dispose() {
-    _controller!.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final List<Photo> picture;
+    final double? height;
+    final double? viewportFraction;
+    var currentPage = useState<int?>(null).value;
+
+    PageController? _controller;
+
+    builder(int index) {
+      double screenWidth = MediaQuery.of(context).size.width;
+      return AnimatedBuilder(
+        animation: _controller!,
+        builder: (context, child) {
+          double value = 1.0;
+          if (_controller!.position.haveDimensions) {
+            value = _controller!.page! - index;
+            value = (1 - (value.abs() * .5)).clamp(0.0, 1.0);
+          }
+
+          return Center(
+            child: SizedBox(
+              height: Curves.easeOut.transform(value) * this.height,
+              width: Curves.easeOut.transform(value) * screenWidth,
+              child: child,
+            ),
+          );
+        },
+        child: Container(
+          child: Stack(
+            children: <Widget>[
+              Positioned(
+                child: Container(
+                  width: double.infinity,
+                  height: this.height,
+                  child: ButtonTheme(
+                    minWidth: double.infinity,
+                    child: TextButton(
+                      onPressed: () => this.onPressed!(index),
+                      child: Row(
+                        children: <Widget>[
+                          Expanded(
+                            // child: CachedNetworkImage(
+                            //   fit: BoxFit.cover,
+                            //   placeholder: Image(
+                            //     image: Theme.Icons.icLoadingImage,
+                            //   ),
+                            //   imageUrl: imgUrls[index],
+                            // )
+                            child: Image.file(
+                              File(this.picture[index].file!.path),
+                              fit: BoxFit.cover,
+                              height: 72,
+                              width: 84,
+                            ),
+                          )
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  margin: EdgeInsets.only(bottom: 20.0),
+                  width: 72.0,
+                  height: 24.0,
+                  decoration: BoxDecoration(
+                    color: Color.fromRGBO(0, 0, 0, 0.3),
+                    borderRadius: BorderRadius.circular(14.0),
+                  ),
+                  child: Center(
+                    child: Text(
+                      '${index + 1} / ${this.picture.length}',
+                      style: TextStyle(
+                        color: const Color(0xffffffff),
+                        fontWeight: FontWeight.w100,
+                        fontFamily: "AppleSDGothicNeo",
+                        fontStyle: FontStyle.normal,
+                        fontSize: 14.0,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    useEffect(() {
+      _controller = PageController(
+        initialPage: currentPage!,
+        keepPage: false,
+        viewportFraction: this.viewportFraction!,
+
+        /// width percentage
+      );
+      return () {
+        _controller!.dispose();
+      };
+    }, []);
+
     return Container(
       height: this.height,
       child: PageView.builder(
-        itemCount: picture.length,
+        itemCount: this.picture.length,
         onPageChanged: (value) {
-          setState(() {
-            this.currentPage = value;
-          });
+          currentPage = value;
         },
         controller: _controller,
         itemBuilder: (context, index) {
           return builder(index);
         },
         pageSnapping: true,
-      ),
-    );
-  }
-
-  builder(int index) {
-    double screenWidth = MediaQuery.of(context).size.width;
-    return AnimatedBuilder(
-      animation: _controller!,
-      builder: (context, child) {
-        double value = 1.0;
-        if (_controller!.position.haveDimensions) {
-          value = _controller!.page! - index;
-          value = (1 - (value.abs() * .5)).clamp(0.0, 1.0);
-        }
-
-        return Center(
-          child: SizedBox(
-            height: Curves.easeOut.transform(value) * widget.height,
-            width: Curves.easeOut.transform(value) * screenWidth,
-            child: child,
-          ),
-        );
-      },
-      child: Container(
-        child: Stack(
-          children: <Widget>[
-            Positioned(
-              child: Container(
-                width: double.infinity,
-                height: widget.height,
-                child: ButtonTheme(
-                  minWidth: double.infinity,
-                  child: TextButton(
-                    onPressed: () => widget.onPressed!(index),
-                    child: Row(
-                      children: <Widget>[
-                        Expanded(
-                          // child: CachedNetworkImage(
-                          //   fit: BoxFit.cover,
-                          //   placeholder: Image(
-                          //     image: Theme.Icons.icLoadingImage,
-                          //   ),
-                          //   imageUrl: imgUrls[index],
-                          // )
-                          child: Image.file(
-                            File(widget.picture[index].file!.path),
-                            fit: BoxFit.cover,
-                            height: 72,
-                            width: 84,
-                          ),
-                        )
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Container(
-                margin: EdgeInsets.only(bottom: 20.0),
-                width: 72.0,
-                height: 24.0,
-                decoration: BoxDecoration(
-                  color: Color.fromRGBO(0, 0, 0, 0.3),
-                  borderRadius: BorderRadius.circular(14.0),
-                ),
-                child: Center(
-                  child: Text(
-                    '${index + 1} / ${picture.length}',
-                    style: TextStyle(
-                      color: const Color(0xffffffff),
-                      fontWeight: FontWeight.w100,
-                      fontFamily: "AppleSDGothicNeo",
-                      fontStyle: FontStyle.normal,
-                      fontSize: 14.0,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/widgets/category_item.dart
+++ b/lib/widgets/category_item.dart
@@ -1,8 +1,9 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/category.dart';
 import 'package:flutter/material.dart';
 
-class CategoryItem extends StatefulWidget {
+class CategoryItem extends HookWidget {
   CategoryItem({
     this.key,
     required this.category,
@@ -15,24 +16,16 @@ class CategoryItem extends StatefulWidget {
   final Function? onSelectPressed;
 
   @override
-  _CategoryItemState createState() => _CategoryItemState(category);
-}
-
-class _CategoryItemState extends State<CategoryItem> {
-  _CategoryItemState(this.category);
-  Category category;
-
-  @override
   Widget build(BuildContext context) {
+    var category = useState<Category>(this.category).value;
+
     return Container(
       margin: EdgeInsets.only(top: 10, bottom: 10, left: 8),
       child: InkWell(
         onTap: () {
-          widget.onSelectPressed!();
+          onSelectPressed!();
         },
-        onLongPress: () => setState(() {
-          category.showDelete = !category.showDelete;
-        }),
+        onLongPress: () => category.showDelete = !category.showDelete,
         child: Stack(
           children: <Widget>[
             Column(
@@ -64,7 +57,7 @@ class _CategoryItemState extends State<CategoryItem> {
                   ? Container(
                       padding: EdgeInsets.all(2),
                       child: InkWell(
-                        onTap: widget.onDeletePressed as void Function()?,
+                        onTap: onDeletePressed as void Function()?,
                         child: ClipOval(
                           child: Container(
                             width: 24,

--- a/lib/widgets/category_item.dart
+++ b/lib/widgets/category_item.dart
@@ -73,7 +73,7 @@ class _CategoryItemState extends State<CategoryItem> {
                                 Theme.of(context).textTheme.displayLarge!.color,
                             child: Icon(
                               Icons.close,
-                              color: Theme.of(context).backgroundColor,
+                              color: Theme.of(context).colorScheme.background,
                               size: 18,
                             ),
                           ),

--- a/lib/widgets/category_item.dart
+++ b/lib/widgets/category_item.dart
@@ -17,7 +17,7 @@ class CategoryItem extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    var category = useState<Category>(this.category).value;
+    var category = useState<Category>(this.category);
 
     return Container(
       margin: EdgeInsets.only(top: 10, bottom: 10, left: 8),
@@ -25,13 +25,14 @@ class CategoryItem extends HookWidget {
         onTap: () {
           onSelectPressed!();
         },
-        onLongPress: () => category.showDelete = !category.showDelete,
+        onLongPress: () =>
+            category.value.showDelete = !category.value.showDelete,
         child: Stack(
           children: <Widget>[
             Column(
               children: <Widget>[
                 Image(
-                  image: category.getIconImage()!,
+                  image: category.value.getIconImage()!,
                   width: 72,
                   height: 72,
                 ),
@@ -39,7 +40,7 @@ class CategoryItem extends HookWidget {
                   margin: EdgeInsets.only(top: 8),
                   width: 80,
                   child: AutoSizeText(
-                    category.label ?? '',
+                    category.value.label ?? '',
                     style: TextStyle(
                       fontSize: 16,
                       color: Theme.of(context).textTheme.displayLarge!.color,
@@ -53,7 +54,7 @@ class CategoryItem extends HookWidget {
             Positioned(
               right: 0,
               top: 0,
-              child: category.showDelete
+              child: category.value.showDelete
                   ? Container(
                       padding: EdgeInsets.all(2),
                       child: InkWell(

--- a/lib/widgets/category_list.dart
+++ b/lib/widgets/category_list.dart
@@ -1,7 +1,7 @@
 import 'package:wecount/models/category.dart';
+import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/category_item.dart';
 import 'package:wecount/utils/db_helper.dart';
-import 'package:wecount/utils/general.dart';
 import 'package:wecount/utils/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
@@ -34,7 +34,7 @@ class _CategoryListState extends State<CategoryList> {
                 Navigator.pop(context, category);
               },
               onDeletePressed: () {
-                General.instance.showConfirmDialog(context,
+                navigation.showConfirmDialog(context,
                     title: Text(_localization!.trans('DELETE')!),
                     content: Text(_localization.trans('DELETE_ASK')!),
                     okPressed: () async {

--- a/lib/widgets/category_list.dart
+++ b/lib/widgets/category_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/category.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/category_item.dart';
@@ -6,22 +7,16 @@ import 'package:wecount/utils/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 
-class CategoryList extends StatefulWidget {
+class CategoryList extends HookWidget {
   CategoryList({
     required this.categories,
   });
   final List<Category> categories;
 
   @override
-  _CategoryListState createState() => _CategoryListState(categories);
-}
-
-class _CategoryListState extends State<CategoryList> {
-  List<Category> categories;
-  _CategoryListState(this.categories);
-
-  @override
   Widget build(BuildContext context) {
+    var categories = useState<List<Category>>(this.categories).value;
+
     var _localization = Localization.of(context);
     return SafeArea(
       child: SingleChildScrollView(
@@ -50,9 +45,7 @@ class _CategoryListState extends State<CategoryList> {
                       fontSize: 16.0,
                     );
                   } finally {
-                    this.setState(() {
-                      categories.remove(category);
-                    });
+                    categories.remove(category);
                     Fluttertoast.showToast(
                       msg: _localization.trans('CATEGORY_DELETED')!,
                       toastLength: Toast.LENGTH_SHORT,

--- a/lib/widgets/category_list.dart
+++ b/lib/widgets/category_list.dart
@@ -15,13 +15,13 @@ class CategoryList extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    var categories = useState<List<Category>>(this.categories).value;
+    var categories = useState<List<Category>>(this.categories);
 
     var _localization = Localization.of(context);
     return SafeArea(
       child: SingleChildScrollView(
         child: Wrap(
-          children: categories.map((Category category) {
+          children: categories.value.map((Category category) {
             return CategoryItem(
               key: Key(category.id.toString()),
               category: category,
@@ -45,7 +45,7 @@ class CategoryList extends HookWidget {
                       fontSize: 16.0,
                     );
                   } finally {
-                    categories.remove(category);
+                    categories.value.remove(category);
                     Fluttertoast.showToast(
                       msg: _localization.trans('CATEGORY_DELETED')!,
                       toastLength: Toast.LENGTH_SHORT,

--- a/lib/widgets/edit_text_box.dart
+++ b/lib/widgets/edit_text_box.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 
-class EditTextBox extends StatefulWidget {
+class EditTextBox extends HookWidget {
   const EditTextBox({
     this.key,
     this.enabled = true,
@@ -54,57 +55,52 @@ class EditTextBox extends StatefulWidget {
   final BorderStyle borderStyle;
 
   @override
-  _EditTextBoxState createState() => _EditTextBoxState();
-}
-
-class _EditTextBoxState extends State<EditTextBox> {
-  FocusNode _focus = FocusNode();
-
-  @override
   Widget build(BuildContext context) {
+    FocusNode _focus = FocusNode();
+
     return Stack(
       alignment: Alignment.center,
       children: <Widget>[
-        widget.iconData != null
+        iconData != null
             ? Positioned(
                 left: 12,
                 bottom: 0,
-                top: widget.margin.top,
+                top: margin.top,
                 child: Container(
                   child: Icon(
-                    widget.iconData,
-                    color: widget.enabledColor,
-                    semanticLabel: widget.semanticLabel,
-                    size: widget.iconSize,
+                    iconData,
+                    color: enabledColor,
+                    semanticLabel: semanticLabel,
+                    size: iconSize,
                   ),
                 ),
               )
             : Container(),
         Container(
           child: TextField(
-            enabled: widget.enabled,
-            controller: widget.controller,
-            style: widget.textStyle ??
+            enabled: enabled,
+            controller: controller,
+            style: textStyle ??
                 TextStyle(
                     color: Theme.of(context).textTheme.displayLarge!.color),
-            cursorColor: widget.focusedColor,
-            onChanged: widget.onChangeText as void Function(String)?,
-            maxLength: widget.maxLength,
+            cursorColor: focusedColor,
+            onChanged: onChangeText as void Function(String)?,
+            maxLength: maxLength,
             focusNode: _focus,
-            maxLines: widget.maxLines,
+            maxLines: maxLines,
             decoration: InputDecoration(
               alignLabelWithHint: true,
-              labelText: widget.labelText,
-              labelStyle: widget.labelStyle,
-              focusColor: widget.focusedColor,
-              hintText: widget.hintText,
-              hintStyle: widget.hintStyle ??
+              labelText: labelText,
+              labelStyle: labelStyle,
+              focusColor: focusedColor,
+              hintText: hintText,
+              hintStyle: hintStyle ??
                   TextStyle(
                       color: Theme.of(context).textTheme.displaySmall!.color),
-              errorText: widget.errorText,
-              errorStyle: widget.errorStyle,
+              errorText: errorText,
+              errorStyle: errorStyle,
               contentPadding: EdgeInsets.only(
-                left: widget.iconData != null ? 48 : 16,
+                left: iconData != null ? 48 : 16,
                 top: 22,
                 bottom: 22,
                 right: 16,
@@ -112,47 +108,47 @@ class _EditTextBoxState extends State<EditTextBox> {
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.focusedColor!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: focusedColor!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.enabledColor!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: enabledColor!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               disabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.disabledColor,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: disabledColor,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               errorBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.errorStyle.color!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: errorStyle.color!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               focusedErrorBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.errorStyle.color!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: errorStyle.color!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
             ),
             autocorrect: false,
           ),
-          margin: widget.margin,
+          margin: margin,
         ),
       ],
     );

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:flutter/material.dart';
 
@@ -82,7 +83,7 @@ Future<PhotoOption?> _asyncPhotoSelect(BuildContext context) async {
       });
 }
 
-class Gallery extends StatefulWidget {
+class Gallery extends HookWidget {
   Gallery({
     this.margin,
     this.showAll = false,
@@ -96,26 +97,19 @@ class Gallery extends StatefulWidget {
   final LedgerItem ledgerItem;
 
   @override
-  _GalleryState createState() => _GalleryState();
-}
-
-class _GalleryState extends State<Gallery> {
-  late List<Photo> _pictures;
-
-  @override
-  void initState() {
-    _pictures = widget.pictures;
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _pictures = useState<List<Photo>>([]).value;
+
+    useEffect(() {
+      _pictures = pictures;
+    }, []);
+
     var _localization = Localization.of(context)!;
 
     void onPressShowAll() {}
 
     return Container(
-      margin: widget.margin,
+      margin: margin,
       child: Column(
         children: <Widget>[
           Row(
@@ -143,7 +137,7 @@ class _GalleryState extends State<Gallery> {
                   ],
                 ),
               ),
-              widget.showAll
+              showAll
                   ? TextButton(
                       onPressed: onPressShowAll,
                       child: Text(
@@ -187,10 +181,8 @@ class _GalleryState extends State<Gallery> {
 
                         if (imgFile != null) {
                           Photo photo = Photo(file: imgFile);
-                          setState(() {
-                            _pictures.add(photo);
-                          });
-                          widget.ledgerItem.picture = _pictures;
+                          _pictures.add(photo);
+                          ledgerItem.picture = _pictures;
                         }
                       },
                       child: Container(
@@ -242,7 +234,7 @@ class _GalleryState extends State<Gallery> {
                                         (Photo compare) =>
                                             compare.file == photo.file);
                                     _pictures.removeAt(index);
-                                    widget.ledgerItem.picture = _pictures;
+                                    ledgerItem.picture = _pictures;
                                     Navigator.of(context).pop();
                                   },
                                 ),

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -76,7 +76,7 @@ Future<PhotoOption?> _asyncPhotoSelect(BuildContext context) async {
               ),
             ),
           ],
-          backgroundColor: Theme.of(context).backgroundColor,
+          backgroundColor: Theme.of(context).colorScheme.background,
         );
       });
 }

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -7,8 +7,8 @@ import 'package:wecount/screens/photo_detail.dart';
 import 'package:wecount/models/photo.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart' show Localization;
-import 'package:wecount/utils/general.dart' show General;
 import 'package:image_picker/image_picker.dart';
+import 'package:wecount/utils/navigation.dart';
 
 enum PhotoOption { Camera, Gallery }
 
@@ -173,12 +173,12 @@ class _GalleryState extends State<Gallery> {
                         XFile? imgFile;
                         switch (photoOption) {
                           case PhotoOption.Camera:
-                            imgFile = await General.instance
-                                .chooseImage(context: context, type: 'camera');
+                            imgFile = await navigation.chooseImage(
+                                context: context, type: 'camera');
                             break;
                           case PhotoOption.Gallery:
-                            imgFile = await General.instance
-                                .chooseImage(context: context, type: 'gallery');
+                            imgFile = await navigation.chooseImage(
+                                context: context, type: 'gallery');
                             break;
                           default:
                             break;
@@ -231,21 +231,19 @@ class _GalleryState extends State<Gallery> {
                             color: Colors.transparent,
                             child: InkWell(
                               splashColor: Asset.Colors.paleGray,
-                              onTap: () => General.instance.navigateScreen(
+                              onTap: () => navigation.navigate(
                                 context,
-                                MaterialPageRoute(
-                                  builder: (BuildContext context) =>
-                                      PhotoDetail(
-                                    photo: photo,
-                                    onPressDelete: () {
-                                      int index = _pictures.indexWhere(
-                                          (Photo compare) =>
-                                              compare.file == photo.file);
-                                      _pictures.removeAt(index);
-                                      widget.ledgerItem.picture = _pictures;
-                                      Navigator.of(context).pop();
-                                    },
-                                  ),
+                                'photo-detail',
+                                arguments: PhotoDetailArguments(
+                                  photo: photo,
+                                  onPressDelete: () {
+                                    int index = _pictures.indexWhere(
+                                        (Photo compare) =>
+                                            compare.file == photo.file);
+                                    _pictures.removeAt(index);
+                                    widget.ledgerItem.picture = _pictures;
+                                    Navigator.of(context).pop();
+                                  },
                                 ),
                               ),
                             ),

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -9,6 +9,7 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:image_picker/image_picker.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 enum PhotoOption { Camera, Gallery }
 
@@ -233,7 +234,7 @@ class _GalleryState extends State<Gallery> {
                               splashColor: Asset.Colors.paleGray,
                               onTap: () => navigation.navigate(
                                 context,
-                                'photo-detail',
+                                AppRoute.photoDetail.fullPath,
                                 arguments: PhotoDetailArguments(
                                   photo: photo,
                                   onPressDelete: () {

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -98,10 +98,10 @@ class Gallery extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    var _pictures = useState<List<Photo>>([]).value;
+    var _pictures = useState<List<Photo>>([]);
 
     useEffect(() {
-      _pictures = pictures;
+      _pictures.value = pictures;
     }, []);
 
     var _localization = Localization.of(context)!;
@@ -157,7 +157,7 @@ class Gallery extends HookWidget {
             width: double.infinity,
             margin: EdgeInsets.only(bottom: 32),
             child: Wrap(
-              children: _pictures.map((Photo photo) {
+              children: _pictures.value.map((Photo photo) {
                 if (photo.isAddBtn == true) {
                   return Container(
                     padding: EdgeInsets.only(right: 4, bottom: 6),
@@ -181,8 +181,8 @@ class Gallery extends HookWidget {
 
                         if (imgFile != null) {
                           Photo photo = Photo(file: imgFile);
-                          _pictures.add(photo);
-                          ledgerItem.picture = _pictures;
+                          _pictures.value.add(photo);
+                          ledgerItem.picture = _pictures.value;
                         }
                       },
                       child: Container(
@@ -230,11 +230,11 @@ class Gallery extends HookWidget {
                                 arguments: PhotoDetailArguments(
                                   photo: photo,
                                   onPressDelete: () {
-                                    int index = _pictures.indexWhere(
+                                    int index = _pictures.value.indexWhere(
                                         (Photo compare) =>
                                             compare.file == photo.file);
-                                    _pictures.removeAt(index);
-                                    ledgerItem.picture = _pictures;
+                                    _pictures.value.removeAt(index);
+                                    ledgerItem.picture = _pictures.value;
                                     Navigator.of(context).pop();
                                   },
                                 ),

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -234,7 +234,7 @@ class _GalleryState extends State<Gallery> {
                               splashColor: Asset.Colors.paleGray,
                               onTap: () => navigation.navigate(
                                 context,
-                                AppRoute.photoDetail.fullPath,
+                                AppRoute.photoDetail.path,
                                 arguments: PhotoDetailArguments(
                                   photo: photo,
                                   onPressDelete: () {

--- a/lib/widgets/home_header_search.dart
+++ b/lib/widgets/home_header_search.dart
@@ -69,51 +69,44 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
           fontSize: 16.0),
       height: 40.0,
     );
-    return AppBar(
-      elevation: 0.0,
-      titleSpacing: 0.0,
-      backgroundColor: widget.color,
-      actions: widget.actions,
-      title: Container(
-        margin: widget.margin,
-        child: Stack(
-          children: <Widget>[
-            textInput,
-            Positioned(
-              child: Container(
-                child: Icon(
-                  Icons.search,
-                  color: Colors.white,
-                ),
-                width: 16.0,
-                height: 16.0,
-              ),
-              left: 12.0,
-              top: 12.0,
-            ),
-            _showClose == true
-                ? Positioned(
-                    child: Container(
-                      child: RawMaterialButton(
-                        onPressed: () {
-                          setState(() {
-                            widget.textEditingController!.clear();
-                            _showClose = false;
-                          });
-                        },
-                        shape: CircleBorder(),
-                        child: Icon(Icons.close, color: Colors.white),
-                        padding: EdgeInsets.all(0.0),
-                      ),
-                      width: 40.0,
-                      height: 40.0,
-                    ),
-                    right: 8.0,
-                  )
-                : Container(height: 40.0),
-          ],
+    return Stack(children: [
+      Container(margin: EdgeInsets.only(left: 20, right: 50), child: textInput),
+      Positioned(
+        child: Container(
+          child: Icon(
+            Icons.search,
+            color: Colors.white,
+          ),
+          width: 16.0,
+          height: 16.0,
         ),
+        left: 32.0,
+        top: 12.0,
       ),
-    );
+      _showClose == true
+          ? Positioned(
+              child: Container(
+                child: RawMaterialButton(
+                  onPressed: () {
+                    setState(() {
+                      widget.textEditingController!.clear();
+                      _showClose = false;
+                    });
+                  },
+                  shape: CircleBorder(),
+                  child: Icon(Icons.close, color: Colors.white),
+                  padding: EdgeInsets.all(0.0),
+                ),
+                width: 50.0,
+              ),
+              right: 0.0,
+            )
+          : Positioned(
+              child: Row(
+                children: widget.actions!,
+              ),
+              right: 0.0,
+            ),
+    ]);
   }
 }

--- a/lib/widgets/home_header_search.dart
+++ b/lib/widgets/home_header_search.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/edit_text_search.dart' show EditTextSearch;
 import 'package:wecount/utils/localization.dart' show Localization;
 
-class HomeHeaderSearch extends StatefulWidget {
+class HomeHeaderSearch extends HookWidget {
   HomeHeaderSearch(
       {Key? key,
       this.margin,
@@ -25,24 +26,17 @@ class HomeHeaderSearch extends StatefulWidget {
   final Function onPressDelete;
 
   @override
-  _HomeHeaderSearchState createState() => _HomeHeaderSearchState();
-}
-
-class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
-  var searchText = "";
-
-  @override
   Widget build(BuildContext context) {
+    var searchText = useState<String>("");
+
     var localization = Localization.of(context)!;
     var textInput = EditTextSearch(
-      controller: widget.textEditingController,
+      controller: textEditingController,
       textInputAction: TextInputAction.search,
       onChanged: (text) {
-        setState(() {
-          searchText = text;
-        });
+        searchText.value = text;
       },
-      onSubmit: widget.onSubmit,
+      onSubmit: onSubmit,
       background: Colors.transparent,
       txtHint: localization.trans('PLZ_SEARCH'),
       underline: false,
@@ -79,13 +73,11 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
         left: 32.0,
         top: 12.0,
       ),
-      searchText != ""
+      searchText.value != ""
           ? Positioned(
               child: Container(
                 child: RawMaterialButton(
-                  onPressed: () {
-                    widget.onPressDelete();
-                  },
+                  onPressed: () => onPressDelete(),
                   shape: CircleBorder(),
                   child: Icon(Icons.close, color: Colors.white),
                   padding: EdgeInsets.all(0.0),
@@ -100,9 +92,7 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () {
-                    widget.onPressAdd();
-                  },
+                  onPressed: () => onPressAdd(),
                   child: Icon(
                     Icons.add,
                     color: Colors.white,

--- a/lib/widgets/home_header_search.dart
+++ b/lib/widgets/home_header_search.dart
@@ -4,30 +4,32 @@ import 'package:wecount/widgets/edit_text_search.dart' show EditTextSearch;
 import 'package:wecount/utils/localization.dart' show Localization;
 
 class HomeHeaderSearch extends StatefulWidget {
-  HomeHeaderSearch({
-    Key? key,
-    this.margin,
-    this.showSearchInput = false,
-    this.textEditingController,
-    this.actions,
-    this.onClose,
-    this.onSubmit,
-    this.color,
-  }) : super(key: key);
+  HomeHeaderSearch(
+      {Key? key,
+      this.margin,
+      this.showSearchInput = false,
+      this.textEditingController,
+      this.onClose,
+      this.onSubmit,
+      this.color,
+      required this.onPressAdd,
+      required this.onPressDelete})
+      : super(key: key);
   final EdgeInsets? margin;
   final bool showSearchInput;
   final TextEditingController? textEditingController;
-  final List<Widget>? actions;
   final Function? onClose;
   final Function? onSubmit;
   final Color? color;
+  final Function onPressAdd;
+  final Function onPressDelete;
 
   @override
   _HomeHeaderSearchState createState() => _HomeHeaderSearchState();
 }
 
 class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
-  bool _showClose = false;
+  var searchText = "";
 
   @override
   Widget build(BuildContext context) {
@@ -36,15 +38,9 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
       controller: widget.textEditingController,
       textInputAction: TextInputAction.search,
       onChanged: (text) {
-        if (text == '') {
-          setState(() {
-            _showClose = false;
-          });
-        } else {
-          setState(() {
-            _showClose = true;
-          });
-        }
+        setState(() {
+          searchText = text;
+        });
       },
       onSubmit: widget.onSubmit,
       background: Colors.transparent,
@@ -83,15 +79,12 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
         left: 32.0,
         top: 12.0,
       ),
-      _showClose == true
+      searchText != ""
           ? Positioned(
               child: Container(
                 child: RawMaterialButton(
                   onPressed: () {
-                    setState(() {
-                      widget.textEditingController!.clear();
-                      _showClose = false;
-                    });
+                    widget.onPressDelete();
                   },
                   shape: CircleBorder(),
                   child: Icon(Icons.close, color: Colors.white),
@@ -102,8 +95,19 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
               right: 0.0,
             )
           : Positioned(
-              child: Row(
-                children: widget.actions!,
+              child: Container(
+                width: 50.0,
+                child: RawMaterialButton(
+                  padding: EdgeInsets.all(0.0),
+                  shape: CircleBorder(),
+                  onPressed: () {
+                    widget.onPressAdd();
+                  },
+                  child: Icon(
+                    Icons.add,
+                    color: Colors.white,
+                  ),
+                ),
               ),
               right: 0.0,
             ),

--- a/lib/widgets/home_list_item.dart
+++ b/lib/widgets/home_list_item.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/utils/logger.dart';
 import 'package:wecount/utils/navigation.dart';
+import 'package:wecount/utils/routes.dart';
 
 class HomeListItem extends StatelessWidget {
   final LedgerItem? ledgerItem;
@@ -62,7 +63,7 @@ class HomeListItem extends StatelessWidget {
         _priceFormatted.toString().replaceAll('-', '');
 
     return TextButton(
-      onPressed: () => navigation.push(context, 'line-graph',
+      onPressed: () => navigation.push(context, AppRoute.lineGraph.fullPath,
           arguments: LineGraphArguments(_label, '2022', ledgerItem!.price)),
       child: Container(
         height: 60,

--- a/lib/widgets/home_list_item.dart
+++ b/lib/widgets/home_list_item.dart
@@ -4,7 +4,8 @@ import 'package:wecount/screens/line_graph.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:intl/intl.dart';
 import 'package:wecount/models/user.dart';
-import 'package:wecount/utils/general.dart' show General;
+import 'package:wecount/utils/logger.dart';
+import 'package:wecount/utils/navigation.dart';
 
 class HomeListItem extends StatelessWidget {
   final LedgerItem? ledgerItem;
@@ -61,8 +62,8 @@ class HomeListItem extends StatelessWidget {
         _priceFormatted.toString().replaceAll('-', '');
 
     return TextButton(
-      onPressed: () =>
-          General.instance.navigateScreenNamed(context, LineGraph.name),
+      onPressed: () => navigation.push(context, 'line-graph',
+          arguments: LineGraphArguments(_label, '2022', ledgerItem!.price)),
       child: Container(
         height: 60,
         child: Row(

--- a/lib/widgets/home_list_item.dart
+++ b/lib/widgets/home_list_item.dart
@@ -63,7 +63,7 @@ class HomeListItem extends StatelessWidget {
         _priceFormatted.toString().replaceAll('-', '');
 
     return TextButton(
-      onPressed: () => navigation.push(context, AppRoute.lineGraph.fullPath,
+      onPressed: () => navigation.push(context, AppRoute.lineGraph.path,
           arguments: LineGraphArguments(_label, '2022', ledgerItem!.price)),
       child: Container(
         height: 60,

--- a/lib/widgets/line_graph_chart.dart
+++ b/lib/widgets/line_graph_chart.dart
@@ -168,7 +168,7 @@ class _LineGraphChartState extends State<LineGraphChart> {
           spots: _spots,
           isCurved: false,
           // colors: gradientColors,
-          color: gradientColors.single,
+          color: gradientColors.first,
           barWidth: 5,
           isStrokeCapRound: true,
           dotData: FlDotData(
@@ -178,7 +178,7 @@ class _LineGraphChartState extends State<LineGraphChart> {
             show: true,
             // colors:
             //     gradientColors.map((color) => color.withOpacity(0.3)).toList(),
-            color: gradientColors.single,
+            color: gradientColors.first,
           ),
         ),
       ],

--- a/lib/widgets/setting_list_item.dart
+++ b/lib/widgets/setting_list_item.dart
@@ -92,7 +92,10 @@ class SettingTileItem extends StatelessWidget {
       onTap: item.onTap as void Function()?,
       child: ListTile(
         leading: item.leading,
-        title: Text(item.title!),
+        title: Text(
+          item.title!,
+          style: TextStyle(color: Colors.black),
+        ),
         trailing: item.trailing,
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,10 @@ description: The social ledger app.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.17.6 <4.0.0"
+
+dependency_overrides:
+  firebase_core_platform_interface: 4.5.1
   
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_native_image: ^0.0.6+1
   logger: ^1.1.0
   flutter_spinkit: ^5.1.0
+  flutter_hooks: ^0.18.5+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,8 @@ dependencies:
   flutter_native_image: ^0.0.6+1
   logger: ^1.1.0
   flutter_spinkit: ^5.1.0
+  flat_list: ^0.1.3
+  flutter_hooks: ^0.18.5+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,8 +58,6 @@ dependencies:
   flutter_native_image: ^0.0.6+1
   logger: ^1.1.0
   flutter_spinkit: ^5.1.0
-  flat_list: ^0.1.3
-  flutter_hooks: ^0.18.5+1
 
 dev_dependencies:
   flutter_test:

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -25,6 +25,7 @@ import 'package:wecount/screens/sign_up.dart' show SignUp;
 import 'package:wecount/screens/find_pw.dart' show FindPw;
 import 'package:wecount/screens/terms.dart' show Terms;
 import 'package:provider/provider.dart';
+import 'package:wecount/utils/routes.dart';
 
 class MockNavigatorObserver extends Mock implements NavigatorObserver {}
 
@@ -44,24 +45,25 @@ class TestUtils {
         home: child,
         navigatorObservers: <NavigatorObserver>[observer],
         routes: {
-          Splash.name: (BuildContext context) => Splash(),
-          Tutorial.name: (BuildContext context) => Tutorial(),
-          Intro.name: (BuildContext context) => Intro(),
-          SignIn.name: (BuildContext context) => SignIn(),
-          SignUp.name: (BuildContext context) => SignUp(),
-          FindPw.name: (BuildContext context) => FindPw(),
-          MainEmpty.name: (BuildContext context) => MainEmpty(),
-          HomeTab.name: (BuildContext context) => HomeTab(),
-          Ledgers.name: (BuildContext context) => Ledgers(),
-          LedgerEdit.name: (BuildContext context) => LedgerEdit(),
-          Terms.name: (BuildContext context) => Terms(),
-          ProfileMy.name: (BuildContext context) => ProfileMy(),
-          Setting.name: (BuildContext context) => Setting(),
-          SettingAnnouncement.name: (BuildContext context) =>
+          AppRoute.splash.fullPath: (BuildContext context) => Splash(),
+          AppRoute.tutorial.fullPath: (BuildContext context) => Tutorial(),
+          AppRoute.intro.fullPath: (BuildContext context) => Intro(),
+          AppRoute.signIn.fullPath: (BuildContext context) => SignIn(),
+          AppRoute.signUp.fullPath: (BuildContext context) => SignUp(),
+          AppRoute.findPw.fullPath: (BuildContext context) => FindPw(),
+          AppRoute.mainEmpty.fullPath: (BuildContext context) => MainEmpty(),
+          AppRoute.homeTab.fullPath: (BuildContext context) => HomeTab(),
+          AppRoute.ledgers.fullPath: (BuildContext context) => Ledgers(),
+          AppRoute.ledgerEdit.fullPath: (BuildContext context) => LedgerEdit(),
+          AppRoute.terms.fullPath: (BuildContext context) => Terms(),
+          AppRoute.profileMy.fullPath: (BuildContext context) => ProfileMy(),
+          AppRoute.setting.fullPath: (BuildContext context) => Setting(),
+          AppRoute.settingAnnouncement.fullPath: (BuildContext context) =>
               SettingAnnouncement(),
-          SettingOpinion.name: (BuildContext context) => SettingOpinion(),
-          SettingFAQ.name: (BuildContext context) => SettingFAQ(),
-          SettingNotification.name: (BuildContext context) =>
+          AppRoute.settingOpinion.fullPath: (BuildContext context) =>
+              SettingOpinion(),
+          AppRoute.settingFAQ.fullPath: (BuildContext context) => SettingFAQ(),
+          AppRoute.settingNotification.fullPath: (BuildContext context) =>
               SettingNotification(),
         },
       ),


### PR DESCRIPTION
## Description

Change all `StatefulWidget` to `hookWidget` using [flutter_hooks][fluuterHookLink] package.
`flutter_hooks` make your code concise and intuitive like Example.

The class containing the variable disappears, and the variable is put in [useState][useStateLink].
Use [useEffect][useEffectLink] instead of super.initState() to handle sideEffect.

## Example

### StatefulWidget
```dart
class MyHomePage extends StatefulWidget {
  @override
  _MyHomePageState createState() => new _MyHomePageState();
}
class _MyHomePageState extends State<MyHomePage> {
  final store = MyStore();
  
  _MyHomePageState();

  @override
  Widget build(BuildContext context) {
    return Container();
  }
}
```

### HookWidget
```dart
class MyHomePage extends HookWidget {
  @override
  Widget build(BuildContext context) {
    final store = useMemoized(() => MyStore());
    return Container();
  }
}
```


[fluuterHookLink]:https://pub.dev/packages/flutter_hooks
[useStateLink]:https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useState.html
[useEffectLink]:https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html