### PR TITLE
refactor: migrate StatefulWidget to HookWidget

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,19 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+
+analyzer:
+  strong-mode:
+    # implicit-casts: false
+    # implicit-dynamic: false
+  exclude:
+    - lib/**.freezed.dart
+    - lib/**.g.dart
+  errors:
+    invalid_annotation_target: ignore
+    # TODO: Remove below rules after refactoring is done
+    unused_local_variable: ignore
+    unused_field: ignore
+    unused_import: ignore
+    unused_element: ignore

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LCXV255WTL;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -399,6 +399,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = wecount;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -407,6 +408,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dooboolab.wecount;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -530,7 +532,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LCXV255WTL;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -538,6 +540,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = wecount;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -546,6 +549,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dooboolab.wecount;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -561,7 +565,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LCXV255WTL;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -569,6 +573,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = wecount;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -577,6 +582,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dooboolab.wecount;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -68,7 +68,7 @@
 				<string>Editor</string>
 				<key>CFBundleURLSchemes</key>
 				<array>
-					<string>com.googleusercontent.apps.221429298568-lhf4eeq02p4bst0ft9gtd65cgqua4ucb</string>
+					<string>com.googleusercontent.apps.764457589810-66l23ggf8l6ilsd157mg4nb0c1k36b0m</string>
 				</array>
 			</dict>
 		</array>

--- a/lib/navigations/home_tab.dart
+++ b/lib/navigations/home_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:provider/provider.dart';
 
 import 'package:wecount/providers/current_ledger.dart';
@@ -8,18 +9,13 @@ import 'package:wecount/screens/home_statistic/home_statistic.dart'
     show HomeStatistic;
 import 'package:wecount/screens/home_setting.dart' show HomeSetting;
 
-class HomeTab extends StatefulWidget {
+class HomeTab extends HookWidget {
   const HomeTab({Key? key}) : super(key: key);
 
   @override
-  _HomeTabState createState() => _HomeTabState();
-}
-
-class _HomeTabState extends State<HomeTab> {
-  int _index = 0;
-
-  @override
   Widget build(BuildContext context) {
+    var _index = useState<int>(0);
+
     String _title = Provider.of<CurrentLedger>(context).getTitle() ?? '';
 
     return Scaffold(
@@ -27,32 +23,32 @@ class _HomeTabState extends State<HomeTab> {
       body: Stack(
         children: <Widget>[
           Offstage(
-            offstage: _index != 0,
+            offstage: _index.value != 0,
             child: TickerMode(
-              enabled: _index == 0,
+              enabled: _index.value == 0,
               child: HomeCalendar(
                 title: _title,
               ),
             ),
           ),
           Offstage(
-            offstage: _index != 1,
+            offstage: _index.value != 1,
             child: TickerMode(
-              enabled: _index == 1,
+              enabled: _index.value == 1,
               child: HomeList(),
             ),
           ),
           Offstage(
-            offstage: _index != 2,
+            offstage: _index.value != 2,
             child: TickerMode(
-              enabled: _index == 2,
+              enabled: _index.value == 2,
               child: HomeStatistic(title: _title),
             ),
           ),
           Offstage(
-            offstage: _index != 3,
+            offstage: _index.value != 3,
             child: TickerMode(
-              enabled: _index == 3,
+              enabled: _index.value == 3,
               child: HomeSetting(
                 title: _title,
               ),
@@ -62,8 +58,8 @@ class _HomeTabState extends State<HomeTab> {
       ),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.shifting,
-        currentIndex: _index,
-        onTap: (int index) => setState(() => this._index = index),
+        currentIndex: _index.value,
+        onTap: (int index) => _index.value = index,
         selectedItemColor: Theme.of(context).textTheme.displayLarge!.color,
         unselectedItemColor: Theme.of(context).textTheme.displayLarge!.color,
         items: <BottomNavigationBarItem>[

--- a/lib/screens/category_add.dart
+++ b/lib/screens/category_add.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:wecount/models/category.dart';
 import 'package:wecount/utils/navigation.dart';
@@ -7,7 +8,7 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/db_helper.dart';
 import 'package:wecount/utils/localization.dart';
 
-class CategoryAdd extends StatefulWidget {
+class CategoryAdd extends HookWidget {
   final CategoryType categoryType;
   final int? lastId;
   CategoryAdd({
@@ -16,23 +17,15 @@ class CategoryAdd extends StatefulWidget {
   });
 
   @override
-  _CategoryAddState createState() => _CategoryAddState();
-}
-
-class _CategoryAddState extends State<CategoryAdd> {
-  int? _selectedIconIndex;
-  TextEditingController _textController = TextEditingController();
-  String? _errorText;
-
-  @override
   Widget build(BuildContext context) {
+    final _textController = useTextEditingController();
+    var _selectedIconIndex = useState<int?>(0);
+    var _errorText = useState<String?>("");
     var _localization = Localization.of(context)!;
 
     void onDonePressed() async {
       if (_textController.text == '') {
-        setState(() {
-          _errorText = _localization.trans('ERROR_CATEGORY_NAME');
-        });
+        _errorText.value = _localization.trans('ERROR_CATEGORY_NAME');
         return;
       }
       if (_selectedIconIndex == null) {
@@ -44,10 +37,10 @@ class _CategoryAddState extends State<CategoryAdd> {
         return;
       }
       Category category = Category(
-        id: widget.lastId! + 1,
-        iconId: _selectedIconIndex,
+        id: lastId! + 1,
+        iconId: _selectedIconIndex.value,
         label: _textController.text,
-        type: widget.categoryType,
+        type: categoryType,
       );
 
       try {
@@ -85,9 +78,7 @@ class _CategoryAddState extends State<CategoryAdd> {
                           padding: EdgeInsets.only(left: 8, bottom: 8),
                           child: InkWell(
                             onTap: () {
-                              setState(() {
-                                _selectedIconIndex = i;
-                              });
+                              _selectedIconIndex.value = i;
                             },
                             child: Opacity(
                               opacity: i == _selectedIconIndex ? 1.0 : 0.4,
@@ -144,7 +135,7 @@ class _CategoryAddState extends State<CategoryAdd> {
                         right: 24,
                       ),
                       hintText: _localization.trans('CATEGORY_ADD_HINT'),
-                      errorText: _errorText,
+                      errorText: _errorText.value,
                     ),
                     Container(
                       child: Row(

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -2,8 +2,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/mocks/home_calendar.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
-import 'package:wecount/screens/ledger_item_edit.dart';
-import 'package:wecount/screens/ledgers.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/date_selector.dart' show DateSelector;

--- a/lib/screens/home_calendar.dart
+++ b/lib/screens/home_calendar.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/mocks/home_calendar.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
@@ -20,18 +21,13 @@ import 'package:flutter_calendar_carousel/classes/event_list.dart';
 import 'package:intl/intl.dart' show DateFormat;
 import 'package:provider/provider.dart';
 
-class HomeCalendar extends StatefulWidget {
+class HomeCalendar extends HookWidget {
   HomeCalendar({
     Key? key,
     this.title = '2022 WeCount',
   }) : super(key: key);
   final String title;
 
-  @override
-  _HomeCalendarState createState() => _HomeCalendarState();
-}
-
-class _HomeCalendarState extends State<HomeCalendar> {
   @override
   Widget build(BuildContext context) {
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
@@ -43,7 +39,7 @@ class _HomeCalendarState extends State<HomeCalendar> {
       body: CustomScrollView(
         slivers: <Widget>[
           HomeHeaderExpanded(
-            title: widget.title,
+            title: title,
             color: Asset.Colors.getColor(color),
             actions: [
               Container(
@@ -85,84 +81,75 @@ class _HomeCalendarState extends State<HomeCalendar> {
   }
 }
 
-class MyHomePage extends StatefulWidget {
+class MyHomePage extends HookWidget {
   MyHomePage({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  DateTime? _currentDate;
-  DateTime? _targetDate;
-  String _currentMonth = '';
-
-  EventList<Event>? _markedDateMap;
-
-  /// ledgerList from parents
-  List<LedgerItem> _ledgerList = [];
-
-  /// for bottom list UI
-  List<LedgerItem> _ledgerListOfSelectedDate = [];
-
-  void selectDate(
-    DateTime date,
-  ) {
-    _ledgerListOfSelectedDate.clear();
-    _ledgerList.forEach((item) {
-      if (item.selectedDate == date) {
-        _ledgerListOfSelectedDate.add(item);
-      }
-    });
-    setState(() {
-      _currentDate = date;
-      _targetDate = DateTime(date.year, date.month);
-      _currentMonth = DateFormat.yMMM().format(date);
-    });
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _currentDate = DateTime.now();
-    _targetDate = DateTime.now();
-    _currentMonth = DateFormat.yMMM().format(_currentDate!);
-
-    Future.delayed(Duration.zero, () {
-      var _localization = Localization.of(context)!;
-
-      List<LedgerItem> ledgerList = createCalendarLedgerItemMock(_localization);
-      EventList<Event>? markedDateMap = EventList(events: {});
-      ledgerList.forEach((ledger) {
-        markedDateMap.add(ledger.selectedDate!,
-            Event(date: ledger.selectedDate!, title: ledger.category!.label));
-      });
-
-      this.setState(() {
-        this._ledgerList = ledgerList;
-        this._markedDateMap = markedDateMap;
-      });
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _currentDate = useState<DateTime?>(DateTime.now());
+    var _targetDate = useState<DateTime?>(DateTime.now());
+    var _currentMonth = useState<String>("");
+
+    var _markedDateMap = useState<EventList<Event>?>(null);
+
+    /// ledgerList from parents
+    var _ledgerList = useState<List<LedgerItem>>([]);
+
+    /// for bottom list UI
+    List<LedgerItem> _ledgerListOfSelectedDate = [];
+
+    void selectDate(
+      DateTime date,
+    ) {
+      _ledgerListOfSelectedDate.clear();
+      _ledgerList.value.forEach((item) {
+        if (item.selectedDate == date) {
+          _ledgerListOfSelectedDate.add(item);
+        }
+      });
+      _currentDate.value = date;
+      _targetDate.value = DateTime(date.year, date.month);
+      _currentMonth.value = DateFormat.yMMM().format(date);
+    }
+
+    useEffect(() {
+      _currentDate.value = DateTime.now();
+      _targetDate.value = DateTime.now();
+      _currentMonth.value = DateFormat.yMMM().format(_currentDate.value!);
+
+      Future.delayed(Duration.zero, () {
+        var _localization = Localization.of(context)!;
+
+        List<LedgerItem> ledgerList =
+            createCalendarLedgerItemMock(_localization);
+        EventList<Event>? markedDateMap = EventList(events: {});
+        ledgerList.forEach((ledger) {
+          markedDateMap.add(ledger.selectedDate!,
+              Event(date: ledger.selectedDate!, title: ledger.category!.label));
+        });
+
+        _ledgerList.value = ledgerList;
+        _markedDateMap.value = markedDateMap;
+      });
+      return null;
+    }, []);
+
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;
 
     void onDatePressed() async {
-      int year = this._currentDate!.year;
+      int year = _currentDate.value!.year;
       int prevDate = year - 100;
       int lastDate = year + 10;
       DateTime? pickDate = await showDatePicker(
         context: context,
-        initialDate: this._currentDate!,
+        initialDate: _currentDate.value!,
         firstDate: DateTime(prevDate),
         lastDate: DateTime(lastDate),
       );
       if (pickDate != null) {
-        this.selectDate(pickDate);
+        selectDate(pickDate);
       }
     }
 
@@ -173,23 +160,21 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           children: <Widget>[
             DateSelector(
-              date: this._currentMonth,
+              date: _currentMonth.value,
               onDatePressed: onDatePressed,
             ),
             renderCalendar(
                 context: context,
                 onCalendarChanged: (DateTime date) {
-                  this.setState(() {
-                    _currentMonth = DateFormat.yMMM().format(date);
-                    _targetDate = date;
-                  });
+                  _currentMonth.value = DateFormat.yMMM().format(date);
+                  _targetDate.value = date;
                 },
                 onDayPressed: (DateTime date, List<Event> events) {
-                  this.selectDate(date);
+                  selectDate(date);
                 },
-                markedDateMap: _markedDateMap,
-                currentDate: _currentDate,
-                targetDate: _targetDate,
+                markedDateMap: _markedDateMap.value,
+                currentDate: _currentDate.value,
+                targetDate: _targetDate.value,
                 color: Asset.Colors.getColor(color)),
             Divider(
               color: Colors.grey,

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -30,45 +30,6 @@ class HomeList extends HookWidget {
     var _data = [];
     var _listData = useState([]);
 
-    Widget _renderListHeader(DateTime date) {
-      String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
-      return Container(
-        color: Colors.white,
-        height: 60.0,
-        padding: EdgeInsets.only(
-          top: 16.0,
-          left: 10.0,
-        ),
-        // padding: EdgeInsets.symmetric(horizontal: 16.0),
-        alignment: Alignment.centerLeft,
-        child: Text(
-          headerString,
-          style: TextStyle(
-            fontSize: 16,
-            color: Theme.of(context).textTheme.displayMedium!.color,
-          ),
-        ),
-      );
-    }
-
-    List<Widget> _renderList(BuildContext context) {
-      return List.generate(_listData.value.length, (index) {
-        var section = _listData.value[index];
-        var headerDate = section['date'];
-        var ledgerItems = section['ledgerItems'];
-        return SliverStickyHeader(
-          header: _renderListHeader(headerDate),
-          sliver: SliverList(
-            key: Key(index.toString()),
-            delegate: SliverChildBuilderDelegate(
-              (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
-              childCount: ledgerItems.length,
-            ),
-          ),
-        );
-      });
-    }
-
     // List<List<LedgerItem>> _ledgerItems = [[]];
     useEffect(() {
       Future.delayed(Duration.zero, () {
@@ -253,7 +214,6 @@ class HomeList extends HookWidget {
             selectedDate: DateTime(2019, 9, 4),
           ),
         );
-
         // sort data
         _data.sort((a, b) {
           return a.selectedDate.compareTo(b.selectedDate);
@@ -286,6 +246,45 @@ class HomeList extends HookWidget {
       });
       return null;
     }, []);
+
+    Widget _renderListHeader(DateTime date) {
+      String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
+      return Container(
+        height: 60.0,
+        color: Colors.white,
+        padding: EdgeInsets.only(
+          top: 16.0,
+          left: 10.0,
+        ),
+        // padding: EdgeInsets.symmetric(horizontal: 16.0),
+        alignment: Alignment.centerLeft,
+        child: Text(
+          headerString,
+          style: TextStyle(
+            fontSize: 16,
+            color: Theme.of(context).textTheme.displayMedium!.color,
+          ),
+        ),
+      );
+    }
+
+    List<Widget> _renderList(BuildContext context) {
+      return List.generate(_listData.value.length, (index) {
+        var section = _listData.value[index];
+        var headerDate = section['date'];
+        var ledgerItems = section['ledgerItems'];
+        return SliverStickyHeader(
+          header: _renderListHeader(headerDate),
+          sliver: SliverList(
+            key: Key(index.toString()),
+            delegate: SliverChildBuilderDelegate(
+              (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
+              childCount: ledgerItems.length,
+            ),
+          ),
+        );
+      });
+    }
 
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
         ? Provider.of<CurrentLedger>(context).getLedger()!.color

--- a/lib/screens/home_list.dart
+++ b/lib/screens/home_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
@@ -17,280 +18,275 @@ import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:provider/provider.dart';
 
-class HomeList extends StatefulWidget {
+class HomeList extends HookWidget {
   HomeList({
     Key? key,
   }) : super(key: key);
 
   @override
-  _HomeListState createState() => _HomeListState();
-}
+  Widget build(BuildContext context) {
+    final textEditingController = useTextEditingController();
 
-class _HomeListState extends State<HomeList> {
-  TextEditingController textEditingController = TextEditingController();
+    var _data = [];
+    var _listData = useState([]);
 
-  var _data = [];
-  var _listData = [];
-
-  // List<List<LedgerItem>> _ledgerItems = [[]];
-  @override
-  void initState() {
-    super.initState();
-    Future.delayed(Duration.zero, () {
-      var _localization = Localization.of(context)!;
-
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 8,
-              label: _localization.trans('EXERCISE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 10),
+    Widget _renderListHeader(DateTime date) {
+      String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
+      return Container(
+        color: Colors.white,
+        height: 60.0,
+        padding: EdgeInsets.only(
+          top: 16.0,
+          left: 10.0,
         ),
-      );
-      _data.add(
-        LedgerItem(
-          price: 300000,
-          category: Category(
-              iconId: 18,
-              label: _localization.trans('WALLET_MONEY'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 10),
-        ),
-      );
-
-      _data.add(
-        LedgerItem(
-          price: -32000,
-          category: Category(
-              iconId: 4,
-              label: _localization.trans('DATING'),
-              type: CategoryType.CONSUME),
-          memo: 'who1 gave me',
-          writer: User(uid: 'who1@gmail.com', displayName: 'engela lee'),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: 300000,
-          category: Category(
-              iconId: 18,
-              label: _localization.trans('WALLET_MONEY'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 8),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 12,
-              label: _localization.trans('PRESENT'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-
-      _data.add(
-        LedgerItem(
-          price: -32000,
-          category: Category(
-              iconId: 4,
-              label: _localization.trans('DATING'),
-              type: CategoryType.CONSUME),
-          memo: 'who1 gave me',
-          writer: User(uid: 'who1@gmail.com', displayName: '이범주'),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 12,
-              label: _localization.trans('PRESENT'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-
-      _data.add(
-        LedgerItem(
-          price: -32000,
-          category: Category(
-              iconId: 4,
-              label: _localization.trans('DATING'),
-              type: CategoryType.CONSUME),
-          memo: 'who1 gave me',
-          writer: User(uid: 'who1@gmail.com', displayName: 'mizcom'),
-          selectedDate: DateTime(2019, 9, 6),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -3100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 4),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -2100,
-          category: Category(
-              iconId: 0,
-              label: _localization.trans('CAFE'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 4),
-        ),
-      );
-      _data.add(
-        LedgerItem(
-          price: -12000,
-          category: Category(
-              iconId: 12,
-              label: _localization.trans('PRESENT'),
-              type: CategoryType.CONSUME),
-          selectedDate: DateTime(2019, 9, 4),
-        ),
-      );
-
-      // sort data
-      _data.sort((a, b) {
-        return a.selectedDate.compareTo(b.selectedDate);
-      });
-
-      // insert Date row as Header
-      DateTime? prevDate;
-      var temp = [];
-      for (var i = 0; i < _data.length; i++) {
-        if (prevDate != _data[i].selectedDate) {
-          // 다르면 모은 데이터를 저장하고, 모음 리셋
-          if (temp.length > 0) {
-            _listData.add({
-              'date': prevDate,
-              'ledgerItems': temp,
-            });
-          }
-          prevDate = _data[i].selectedDate;
-          temp = [];
-        }
-        temp.add(_data[i]); // 데이터 임시 모음
-        // _listData.add(_data[i]);
-      }
-      if (temp.length > 0) {
-        _listData.add({
-          'date': prevDate,
-          'ledgerItems': temp,
-        });
-      }
-    });
-  }
-
-  Widget _renderListHeader(DateTime date) {
-    String headerString = DateFormat('yyyy-MM-dd (E)').format(date);
-    return Container(
-      height: 60.0,
-      padding: EdgeInsets.only(
-        top: 16.0,
-        left: 10.0,
-      ),
-      // padding: EdgeInsets.symmetric(horizontal: 16.0),
-      alignment: Alignment.centerLeft,
-      child: Text(
-        headerString,
-        style: TextStyle(
-          fontSize: 16,
-          color: Theme.of(context).textTheme.displayMedium!.color,
-        ),
-      ),
-    );
-  }
-
-  List<Widget> _renderList(BuildContext context) {
-    return List.generate(_listData.length, (index) {
-      var section = _listData[index];
-      var headerDate = section['date'];
-      var ledgerItems = section['ledgerItems'];
-      return SliverStickyHeader(
-        header: _renderListHeader(headerDate),
-        sliver: SliverList(
-          key: Key(index.toString()),
-          delegate: SliverChildBuilderDelegate(
-            (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
-            childCount: ledgerItems.length,
+        // padding: EdgeInsets.symmetric(horizontal: 16.0),
+        alignment: Alignment.centerLeft,
+        child: Text(
+          headerString,
+          style: TextStyle(
+            fontSize: 16,
+            color: Theme.of(context).textTheme.displayMedium!.color,
           ),
         ),
       );
-    });
-  }
+    }
 
-  @override
-  Widget build(BuildContext context) {
+    List<Widget> _renderList(BuildContext context) {
+      return List.generate(_listData.value.length, (index) {
+        var section = _listData.value[index];
+        var headerDate = section['date'];
+        var ledgerItems = section['ledgerItems'];
+        return SliverStickyHeader(
+          header: _renderListHeader(headerDate),
+          sliver: SliverList(
+            key: Key(index.toString()),
+            delegate: SliverChildBuilderDelegate(
+              (context, i) => HomeListItem(ledgerItem: ledgerItems[i]),
+              childCount: ledgerItems.length,
+            ),
+          ),
+        );
+      });
+    }
+
+    // List<List<LedgerItem>> _ledgerItems = [[]];
+    useEffect(() {
+      Future.delayed(Duration.zero, () {
+        var _localization = Localization.of(context)!;
+
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 8,
+                label: _localization.trans('EXERCISE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 10),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: 300000,
+            category: Category(
+                iconId: 18,
+                label: _localization.trans('WALLET_MONEY'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 10),
+          ),
+        );
+
+        _data.add(
+          LedgerItem(
+            price: -32000,
+            category: Category(
+                iconId: 4,
+                label: _localization.trans('DATING'),
+                type: CategoryType.CONSUME),
+            memo: 'who1 gave me',
+            writer: User(uid: 'who1@gmail.com', displayName: 'engela lee'),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: 300000,
+            category: Category(
+                iconId: 18,
+                label: _localization.trans('WALLET_MONEY'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 8),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 12,
+                label: _localization.trans('PRESENT'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+
+        _data.add(
+          LedgerItem(
+            price: -32000,
+            category: Category(
+                iconId: 4,
+                label: _localization.trans('DATING'),
+                type: CategoryType.CONSUME),
+            memo: 'who1 gave me',
+            writer: User(uid: 'who1@gmail.com', displayName: '이범주'),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 12,
+                label: _localization.trans('PRESENT'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+
+        _data.add(
+          LedgerItem(
+            price: -32000,
+            category: Category(
+                iconId: 4,
+                label: _localization.trans('DATING'),
+                type: CategoryType.CONSUME),
+            memo: 'who1 gave me',
+            writer: User(uid: 'who1@gmail.com', displayName: 'mizcom'),
+            selectedDate: DateTime(2019, 9, 6),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -3100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 4),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -2100,
+            category: Category(
+                iconId: 0,
+                label: _localization.trans('CAFE'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 4),
+          ),
+        );
+        _data.add(
+          LedgerItem(
+            price: -12000,
+            category: Category(
+                iconId: 12,
+                label: _localization.trans('PRESENT'),
+                type: CategoryType.CONSUME),
+            selectedDate: DateTime(2019, 9, 4),
+          ),
+        );
+
+        // sort data
+        _data.sort((a, b) {
+          return a.selectedDate.compareTo(b.selectedDate);
+        });
+
+        // insert Date row as Header
+        DateTime? prevDate;
+        var temp = [];
+        for (var i = 0; i < _data.length; i++) {
+          if (prevDate != _data[i].selectedDate) {
+            // 다르면 모은 데이터를 저장하고, 모음 리셋
+            if (temp.length > 0) {
+              _listData.value.add({
+                'date': prevDate,
+                'ledgerItems': temp,
+              });
+            }
+            prevDate = _data[i].selectedDate;
+            temp = [];
+          }
+          temp.add(_data[i]); // 데이터 임시 모음
+          // _listData.add(_data[i]);
+        }
+        if (temp.length > 0) {
+          _listData.value.add({
+            'date': prevDate,
+            'ledgerItems': temp,
+          });
+        }
+      });
+      return null;
+    }, []);
+
     var color = Provider.of<CurrentLedger>(context).getLedger() != null
         ? Provider.of<CurrentLedger>(context).getLedger()!.color
         : ColorType.DUSK;

--- a/lib/screens/home_setting.dart
+++ b/lib/screens/home_setting.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:wecount/types/color.dart';
 import 'package:flutter/material.dart';
@@ -12,18 +13,13 @@ import '../widgets/setting_list_item.dart'
     show ListItem, TileItem, SettingTileItem;
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
-class HomeSetting extends StatefulWidget {
+class HomeSetting extends HookWidget {
   HomeSetting({
     Key? key,
     this.title = '',
   }) : super(key: key);
   final String title;
 
-  @override
-  _HomeSettingState createState() => _HomeSettingState();
-}
-
-class _HomeSettingState extends State<HomeSetting> {
   @override
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
@@ -57,7 +53,7 @@ class _HomeSettingState extends State<HomeSetting> {
     return Scaffold(
       appBar: renderHomeAppBar(
         context: context,
-        title: widget.title,
+        title: title,
         color: Asset.Colors.getColor(color),
         fontColor: Colors.white,
       ),

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -77,10 +77,10 @@ class Content extends HookWidget {
 
     /// State
     DateTime _date = DateTime.now();
-    Map<String, double>? _dataMapIncome = Map();
-    Map<String, double>? _dataMapExpense = Map();
-    var _condensedLedgerList = useState<List<LedgerItem>>([]).value;
-    var _selectedChart = useState<int?>(null).value;
+    var _dataMapIncome = useState<Map<String, double>?>(Map());
+    var _dataMapExpense = useState<Map<String, double>?>(Map());
+    var _condensedLedgerList = useState<List<LedgerItem>>([]);
+    var _selectedChart = useState<int?>(null);
 
     List<Color> colorList = [
       Asset.Colors.blue,
@@ -100,9 +100,9 @@ class Content extends HookWidget {
       var result = splitLedgers(condensedLedgerList);
       // ledgerList.addAll(normalIncomeList(localization, 10));
 
-      _condensedLedgerList = condensedLedgerList;
-      _dataMapIncome = result['income'];
-      _dataMapExpense = result['expense'];
+      _condensedLedgerList.value = condensedLedgerList;
+      _dataMapIncome.value = result['income'];
+      _dataMapExpense.value = result['expense'];
     }
 
     ;
@@ -114,7 +114,7 @@ class Content extends HookWidget {
         _ledgerList = createHomeStatisticMock(Localization.of(context)!);
 
         calculateAndRender(_date.month.toString(), _ledgerList);
-        _selectedChart = 1;
+        _selectedChart.value = 1;
       });
       return null;
     }, []);
@@ -136,8 +136,9 @@ class Content extends HookWidget {
       // }
     }
 
-    Map<String, double> dataMap =
-        _selectedChart == 1 ? _dataMapIncome! : _dataMapExpense!;
+    Map<String, double> dataMap = _selectedChart.value == 1
+        ? _dataMapIncome.value!
+        : _dataMapExpense.value!;
 
     /// PieChart throws error when `_dataMap` is empty
     var chartWidget = dataMap.length > 0
@@ -167,7 +168,7 @@ class Content extends HookWidget {
                 ),
                 Text(
                   localization!.trans('NO_DATA')!,
-                  style: TextStyle(),
+                  style: TextStyle(color: Colors.black),
                 ),
               ],
               direction: Axis.vertical,
@@ -180,9 +181,9 @@ class Content extends HookWidget {
       shrinkWrap: true,
       physics: NeverScrollableScrollPhysics(),
       padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-      itemCount: _condensedLedgerList.length,
+      itemCount: _condensedLedgerList.value.length,
       itemBuilder: (BuildContext context, int index) {
-        return HomeListItem(ledgerItem: _condensedLedgerList[index]);
+        return HomeListItem(ledgerItem: _condensedLedgerList.value[index]);
       },
     );
 
@@ -204,10 +205,10 @@ class Content extends HookWidget {
             ),
             ButtonGroup(
               onButtonOnePressed: () {
-                _selectedChart = 1;
+                _selectedChart.value = 1;
               },
               onButtonTwoPressed: () {
-                _selectedChart = 2;
+                _selectedChart.value = 2;
               },
               selected: _selectedChart,
             ),

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -168,7 +168,7 @@ class Content extends HookWidget {
                 ),
                 Text(
                   localization!.trans('NO_DATA')!,
-                  style: TextStyle(color: Colors.black),
+                  style: TextStyle(),
                 ),
               ],
               direction: Axis.vertical,
@@ -210,7 +210,7 @@ class Content extends HookWidget {
               onButtonTwoPressed: () {
                 _selectedChart.value = 2;
               },
-              selected: _selectedChart,
+              selected: _selectedChart.value,
             ),
             chartWidget,
             bottomListWidget,

--- a/lib/screens/home_statistic/home_statistic.dart
+++ b/lib/screens/home_statistic/home_statistic.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/mocks/home_statistic.mock.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:wecount/providers/current_ledger.dart';
@@ -66,67 +67,61 @@ class HomeStatistic extends StatelessWidget {
   }
 }
 
-class Content extends StatefulWidget {
+class Content extends HookWidget {
   Content({Key? key}) : super(key: key);
 
   @override
-  _ContentState createState() => _ContentState();
-}
-
-class _ContentState extends State<Content> {
-  /// From parent
-  late List<LedgerItem> _ledgerList;
-
-  /// State
-  DateTime _date = DateTime.now();
-  List<LedgerItem> _condensedLedgerList = [];
-  Map<String, double>? _dataMapIncome = Map();
-  Map<String, double>? _dataMapExpense = Map();
-  int? _selectedChart;
-
-  List<Color> colorList = [
-    Asset.Colors.blue,
-    Asset.Colors.orange,
-    Asset.Colors.green,
-    Asset.Colors.yellow,
-    Asset.Colors.purple,
-    Asset.Colors.main,
-    Asset.Colors.red,
-  ];
-
-  @override
-  void initState() {
-    super.initState();
-    Future.delayed(Duration.zero, () {
-      _ledgerList = createHomeStatisticMock(Localization.of(context)!);
-
-      calculateAndRender(this._date.month.toString(), _ledgerList);
-      this.setState(() => this._selectedChart = 1);
-    });
-  }
-
-  void calculateAndRender(String month, List<LedgerItem> ledgerList) {
-    var ledgerListOfSelectedMonth = ledgerListByMonth(month, ledgerList);
-
-    /// sum up same category into one. but before that I can make ui first
-    var condensedLedgerList = condense(ledgerListOfSelectedMonth);
-    var result = splitLedgers(condensedLedgerList);
-    // ledgerList.addAll(normalIncomeList(localization, 10));
-
-    this.setState(() {
-      this._condensedLedgerList = condensedLedgerList;
-      this._dataMapIncome = result['income'];
-      this._dataMapExpense = result['expense'];
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
+    /// From parent
+    late List<LedgerItem> _ledgerList;
+
+    /// State
+    DateTime _date = DateTime.now();
+    Map<String, double>? _dataMapIncome = Map();
+    Map<String, double>? _dataMapExpense = Map();
+    var _condensedLedgerList = useState<List<LedgerItem>>([]).value;
+    var _selectedChart = useState<int?>(null).value;
+
+    List<Color> colorList = [
+      Asset.Colors.blue,
+      Asset.Colors.orange,
+      Asset.Colors.green,
+      Asset.Colors.yellow,
+      Asset.Colors.purple,
+      Asset.Colors.main,
+      Asset.Colors.red,
+    ];
+
+    void calculateAndRender(String month, List<LedgerItem> ledgerList) {
+      var ledgerListOfSelectedMonth = ledgerListByMonth(month, ledgerList);
+
+      /// sum up same category into one. but before that I can make ui first
+      var condensedLedgerList = condense(ledgerListOfSelectedMonth);
+      var result = splitLedgers(condensedLedgerList);
+      // ledgerList.addAll(normalIncomeList(localization, 10));
+
+      _condensedLedgerList = condensedLedgerList;
+      _dataMapIncome = result['income'];
+      _dataMapExpense = result['expense'];
+    }
+
+    ;
+
     var localization = Localization.of(context);
+
+    useEffect(() {
+      Future.delayed(Duration.zero, () {
+        _ledgerList = createHomeStatisticMock(Localization.of(context)!);
+
+        calculateAndRender(_date.month.toString(), _ledgerList);
+        _selectedChart = 1;
+      });
+      return null;
+    }, []);
 
     /// Month select Widget -> select month, set _date and calculate
     void onDatePressed() async {
-      int year = this._date.year;
+      int year = _date.year;
       int prevDate = year - 100;
       int lastDate = year + 10;
       // DateTime? pickDate = await showMonthPicker(
@@ -142,7 +137,7 @@ class _ContentState extends State<Content> {
     }
 
     Map<String, double> dataMap =
-        this._selectedChart == 1 ? this._dataMapIncome! : this._dataMapExpense!;
+        _selectedChart == 1 ? _dataMapIncome! : _dataMapExpense!;
 
     /// PieChart throws error when `_dataMap` is empty
     var chartWidget = dataMap.length > 0
@@ -209,16 +204,12 @@ class _ContentState extends State<Content> {
             ),
             ButtonGroup(
               onButtonOnePressed: () {
-                this.setState(() {
-                  this._selectedChart = 1;
-                });
+                _selectedChart = 1;
               },
               onButtonTwoPressed: () {
-                this.setState(() {
-                  this._selectedChart = 2;
-                });
+                _selectedChart = 2;
               },
-              selected: this._selectedChart,
+              selected: _selectedChart,
             ),
             chartWidget,
             bottomListWidget,

--- a/lib/screens/ledger_edit.dart
+++ b/lib/screens/ledger_edit.dart
@@ -41,6 +41,7 @@ class LedgerEdit extends HookWidget {
   Widget build(BuildContext context) {
     var _ledger = useState<Ledger?>(null);
     var _isLoading = useState<bool>(false);
+    var color = useState<ColorType?>(null);
 
     useEffect(() {
       if (ledger == null) {
@@ -72,6 +73,7 @@ class LedgerEdit extends HookWidget {
     }
 
     void _selectColor(ColorType item) {
+      color.value = item;
       _ledger.value!.color = item;
     }
 
@@ -342,7 +344,8 @@ class LedgerEdit extends HookWidget {
                               ? _localization.trans('DONE')!
                               : _localization.trans('UPDATE')!,
                           style: TextStyle(
-                            color: Asset.Colors.getColor(_ledger.value!.color),
+                            color: Colors.black,
+                            // color: Asset.Colors.getColor(_ledger.value!.color),
                             fontSize: 16.0,
                           ),
                         ),

--- a/lib/screens/ledger_view.dart
+++ b/lib/screens/ledger_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/member_horizontal_list.dart';
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
@@ -14,38 +15,34 @@ class LedgerViewArguments {
   LedgerViewArguments({this.ledger});
 }
 
-class LedgerView extends StatefulWidget {
-  final Ledger? ledger;
+class LedgerView extends HookWidget {
   const LedgerView({
     Key? key,
     this.ledger,
   }) : super(key: key);
-
-  @override
-  _LedgerViewState createState() => _LedgerViewState(ledger);
-}
-
-class _LedgerViewState extends State<LedgerView> {
-  late Ledger _ledger;
-
-  _LedgerViewState(Ledger? ledger) {
-    if (ledger != null) {
-      _ledger = ledger;
-      return;
-    }
-    _ledger = Ledger(
-      title: 'ledger test',
-      currency: Currency(currency: '\￦', locale: 'KRW'),
-      color: ColorType.DUSK,
-    );
-  }
+  final Ledger? ledger;
 
   @override
   Widget build(BuildContext context) {
+    var _ledger = useState<Ledger?>(null);
+
+    useEffect(() {
+      if (ledger != null) {
+        _ledger.value = ledger;
+        return;
+      }
+      _ledger.value = Ledger(
+        title: 'ledger test',
+        currency: Currency(currency: '\￦', locale: 'KRW'),
+        color: ColorType.DUSK,
+      );
+      return null;
+    }, []);
+
     var _localization = Localization.of(context)!;
 
     return Scaffold(
-      backgroundColor: Asset.Colors.getColor(_ledger.color),
+      backgroundColor: Asset.Colors.getColor(_ledger.value!.color),
       appBar: renderHeaderBack(
         context: context,
         iconColor: Colors.white,
@@ -60,9 +57,9 @@ class _LedgerViewState extends State<LedgerView> {
                 enabled: false,
                 maxLines: 2,
                 onChanged: (String txt) {
-                  _ledger.title = txt;
+                  _ledger.value!.title = txt;
                 },
-                controller: TextEditingController(text: _ledger.title),
+                controller: TextEditingController(text: _ledger.value!.title),
                 decoration: InputDecoration(
                   hintMaxLines: 2,
                   border: InputBorder.none,
@@ -84,9 +81,10 @@ class _LedgerViewState extends State<LedgerView> {
               child: TextField(
                 enabled: false,
                 maxLines: 8,
-                controller: TextEditingController(text: _ledger.description),
+                controller:
+                    TextEditingController(text: _ledger.value!.description),
                 onChanged: (String txt) {
-                  _ledger.description = txt;
+                  _ledger.value!.description = txt;
                 },
                 textAlignVertical: TextAlignVertical.top,
                 decoration: InputDecoration(
@@ -123,7 +121,7 @@ class _LedgerViewState extends State<LedgerView> {
                     Row(
                       children: <Widget>[
                         Text(
-                          '${_ledger.currency.locale} | ${_ledger.currency.currency}',
+                          '${_ledger.value!.currency.locale} | ${_ledger.value!.currency.currency}',
                           style: TextStyle(
                             color: Colors.white,
                             fontSize: 16,
@@ -170,7 +168,7 @@ class _LedgerViewState extends State<LedgerView> {
                         itemExtent: 32,
                         itemBuilder: (context, index) {
                           final item = colorItems[index];
-                          bool selected = item == _ledger.color;
+                          bool selected = item == _ledger.value!.color;
                           return ColorItem(
                             color: item,
                             selected: selected,

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -83,7 +83,6 @@ class Ledgers extends HookWidget {
                   if (!snapshot.hasData) return Container();
 
                   var profile = snapshot.data;
-
                   return ProfileListItem(
                     email: profile.email ?? '',
                     displayName: profile.displayName ?? '',

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/providers/current_ledger.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -15,14 +16,9 @@ import 'package:wecount/utils/localization.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:provider/provider.dart' show Provider;
 
-class Ledgers extends StatefulWidget {
+class Ledgers extends HookWidget {
   const Ledgers({Key? key}) : super(key: key);
 
-  @override
-  _LedgersState createState() => _LedgersState();
-}
-
-class _LedgersState extends State<Ledgers> {
   @override
   Widget build(BuildContext context) {
     User? user = FirebaseAuth.instance.currentUser!;

--- a/lib/screens/location_view.dart
+++ b/lib/screens/location_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:geocoding/geocoding.dart'
     show Placemark, placemarkFromCoordinates;
 import 'package:wecount/widgets/header.dart';
@@ -7,108 +8,100 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
-class LocationView extends StatefulWidget {
+class LocationView extends HookWidget {
   const LocationView({Key? key}) : super(key: key);
 
   @override
-  _LocationViewState createState() => _LocationViewState();
-}
-
-class _LocationViewState extends State<LocationView> {
-  late GoogleMapController mapController;
-  LatLng? _center;
-  Map<MarkerId, Marker> markers = <MarkerId, Marker>{};
-  late Set<Marker> _markerSet;
-  late String _countryCode;
-
-  @override
-  void initState() {
-    _countryCode = WidgetsBinding.instance.window.locale.countryCode!;
-    super.initState();
-    getCurrentLocation();
-  }
-
-  /// Open up google place search screen. The `_countryCode` is used to query google places.
-  ///
-  /// Get `lat` and `lng` from the places search.
-  /// Move camera and set markers when there is a result.
-  ///
-  void getPlace() async {
-    var location = await GooglePlaceService.instance.showGooglePlaceSearch(
-      context,
-      country: _countryCode,
-    );
-
-    if (location['lat'] != null && location['lng'] != null) {
-      var latLng = LatLng(location['lat'], location['lng']);
-      _setMarker(latLng);
-
-      setState(() => _center = latLng);
-
-      CameraUpdate cameraUpdate = CameraUpdate.newLatLng(latLng);
-      mapController.moveCamera(cameraUpdate);
-    }
-  }
-
-  /// Get current location with `location` plugin.
-  ///
-  /// This will request permission in android when it's not granted.
-  /// When permission is granted, it will get current location by calling `getLocation`,
-  /// and set markers when result is achieved.
-  ///
-  /// It also fetches current `countryCode` to be used when searching google places.
-  ///
-  void getCurrentLocation() async {
-    var currentLocation;
-    var error;
-
-    var location = Location();
-
-    try {
-      currentLocation = await location.getLocation();
-    } catch (e) {
-      // if (e.currency == 'PERMISSION_DENIED') {
-      //   error = 'Permission denied';
-      // }
-      currentLocation = null;
-    }
-
-    if (error == null) {
-      final LatLng latLng =
-          LatLng(currentLocation.latitude, currentLocation.longitude);
-      _setMarker(latLng);
-
-      setState(() => _center = latLng);
-      return;
-    }
-
-    setState(() => _center = LatLng(0, 0));
-  }
-
-  void _setMarker(LatLng latLng) {
-    MarkerId markerId = MarkerId('myMarker');
-
-    // creating a new MARKER
-    final Marker marker = Marker(
-      markerId: markerId,
-      position: latLng,
-    );
-
-    markers[markerId] = marker;
-
-    setState(() {
-      _markerSet = Set<Marker>.of(markers.values);
-    });
-  }
-
-  void _onMapCreated(GoogleMapController controller) {
-    mapController = controller;
-  }
-
-  void _onCameraMoved(CameraPosition pos) => _setMarker(pos.target);
-
-  @override
   Widget build(BuildContext context) {
+    late GoogleMapController mapController;
+    var _center = useState<LatLng?>(null);
+    var _markerSet = useState<Set<Marker>>({});
+    Map<MarkerId, Marker> markers = <MarkerId, Marker>{};
+    late String _countryCode;
+
+    void _setMarker(LatLng latLng) {
+      MarkerId markerId = MarkerId('myMarker');
+
+      // creating a new MARKER
+      final Marker marker = Marker(
+        markerId: markerId,
+        position: latLng,
+      );
+
+      markers[markerId] = marker;
+
+      _markerSet.value = Set<Marker>.of(markers.values);
+    }
+
+    /// Get current location with `location` plugin.
+    ///
+    /// This will request permission in android when it's not granted.
+    /// When permission is granted, it will get current location by calling `getLocation`,
+    /// and set markers when result is achieved.
+    ///
+    /// It also fetches current `countryCode` to be used when searching google places.
+    ///
+    void getCurrentLocation() async {
+      var currentLocation;
+      var error;
+
+      var location = Location();
+
+      try {
+        currentLocation = await location.getLocation();
+      } catch (e) {
+        // if (e.currency == 'PERMISSION_DENIED') {
+        //   error = 'Permission denied';
+        // }
+        currentLocation = null;
+      }
+
+      if (error == null) {
+        final LatLng latLng =
+            LatLng(currentLocation.latitude, currentLocation.longitude);
+        _setMarker(latLng);
+
+        _center.value = latLng;
+        return;
+      }
+
+      _center.value = LatLng(0, 0);
+    }
+
+    useEffect(() {
+      _countryCode = WidgetsBinding.instance.window.locale.countryCode!;
+      getCurrentLocation();
+      return null;
+    }, []);
+
+    /// Open up google place search screen. The `_countryCode` is used to query google places.
+    ///
+    /// Get `lat` and `lng` from the places search.
+    /// Move camera and set markers when there is a result.
+    ///
+    void getPlace() async {
+      var location = await GooglePlaceService.instance.showGooglePlaceSearch(
+        context,
+        country: _countryCode,
+      );
+
+      if (location['lat'] != null && location['lng'] != null) {
+        var latLng = LatLng(location['lat'], location['lng']);
+        _setMarker(latLng);
+
+        _center.value = latLng;
+
+        CameraUpdate cameraUpdate = CameraUpdate.newLatLng(latLng);
+        mapController.moveCamera(cameraUpdate);
+      }
+    }
+
+    void _onMapCreated(GoogleMapController controller) {
+      mapController = controller;
+    }
+
+    void _onCameraMoved(CameraPosition pos) => _setMarker(pos.target);
+
     return _center == null
         ? const LoadingIndicator()
         : Scaffold(
@@ -142,8 +135,8 @@ class _LocationViewState extends State<LocationView> {
                     onPressed: () async {
                       List<Placemark> addresses =
                           await placemarkFromCoordinates(
-                        _center!.latitude,
-                        _center!.longitude,
+                        _center.value!.latitude,
+                        _center.value!.longitude,
                       );
                       Map<String, dynamic> result = Map();
                       result['address'] = addresses.first.street;
@@ -162,10 +155,10 @@ class _LocationViewState extends State<LocationView> {
             body: GoogleMap(
               onMapCreated: _onMapCreated,
               initialCameraPosition: CameraPosition(
-                target: _center!,
+                target: _center.value!,
                 zoom: 11.0,
               ),
-              markers: _markerSet,
+              markers: _markerSet.value,
               onCameraMove: _onCameraMoved,
             ),
           );

--- a/lib/screens/lock_auth.dart
+++ b/lib/screens/lock_auth.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
 import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
@@ -10,123 +11,179 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:local_auth/local_auth.dart';
 
-class LockAuth extends StatefulWidget {
+class LockAuth extends HookWidget {
   const LockAuth({Key? key}) : super(key: key);
 
   @override
-  _LockAuthState createState() => _LockAuthState();
-}
-
-class _LockAuthState extends State<LockAuth> {
-  late Size _screenSize;
-  int? _currentDigit;
-
-  int? _firstDigit;
-  int? _secondDigit;
-  int? _thirdDigit;
-  int? _fourthDigit;
-
-  Localization? _localization;
-
-  String? _pin = '';
-  String _inputPin = '';
-
-  /// LocalAuthentication - Fingerprint
-  final LocalAuthentication _localAuthentication = LocalAuthentication();
-  bool _hasFingerPrintSupport = false;
-
-  Future<void> checkFingerprintSupport() async {
-    bool isBiometricSupport = false;
-    List<BiometricType> availableBiometricType = [];
-
-    try {
-      isBiometricSupport = await _localAuthentication.canCheckBiometrics;
-      if (!isBiometricSupport) return;
-    } catch (e) {
-      print(e);
-    }
-    if (!mounted) return;
-
-    try {
-      availableBiometricType =
-          await _localAuthentication.getAvailableBiometrics();
-    } catch (e) {
-      print(e);
-    }
-    if (!mounted) return;
-
-    setState(() {
-      if (availableBiometricType.contains(BiometricType.fingerprint)) {
-        _hasFingerPrintSupport = true;
-      } else {
-        _hasFingerPrintSupport = false;
-      }
-    });
-  }
-
-  Future<void> _authenticateMe() async {
-    // 8. this method opens a dialog for fingerprint authentication.
-    //    we do not need to create a dialog nut it pop sup from device natively.
-    bool authenticated = false;
-    try {
-      authenticated = await _localAuthentication.authenticate(
-        localizedReason:
-            _localization!.trans('FINGERPRINT_LOGIN')!, // message for dialog
-        options: AuthenticationOptions(
-          useErrorDialogs: true,
-          stickyAuth: true,
-        ),
-      );
-    } catch (e) {
-      print(e);
-    }
-    if (!mounted) return;
-
-    if (authenticated) {
-      Navigator.pop(context, false);
-    } else {
-      return;
-    }
-  }
-
-  readLockPinFromSF() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-
-    if (prefs.containsKey('LOCK_PIN')) {
-      _pin = prefs.getString('LOCK_PIN');
-      print(_pin);
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-    ]);
-
-    checkFingerprintSupport();
-    readLockPinFromSF();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-      DeviceOrientation.portraitDown,
-      DeviceOrientation.portraitUp,
-    ]);
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final mounted = useIsMounted();
+    late Size _screenSize;
+    var _currentDigit = useState<int?>(0);
+
+    var _firstDigit = useState<int?>(null);
+    var _secondDigit = useState<int?>(null);
+    var _thirdDigit = useState<int?>(null);
+    var _fourthDigit = useState<int?>(null);
+
+    Localization? _localization;
+    String? _pin = '';
+    String _inputPin = '';
+
+    void _setCurrentDigit(int i) {
+      _currentDigit.value = i;
+      if (_firstDigit.value == null) {
+        _firstDigit.value = _currentDigit.value;
+      } else if (_secondDigit.value == null) {
+        _secondDigit.value = _currentDigit.value;
+      } else if (_thirdDigit.value == null) {
+        _thirdDigit.value = _currentDigit.value;
+      } else if (_fourthDigit.value == null) {
+        _fourthDigit.value = _currentDigit.value;
+
+        _inputPin = _firstDigit.toString() +
+            _secondDigit.toString() +
+            _thirdDigit.toString() +
+            _fourthDigit.toString();
+
+        print('INPUT PIN is $_inputPin');
+      }
+
+      if (_inputPin.length == 4) {
+        if (_inputPin == _pin) {
+          Navigator.pop(context, false);
+        } else {
+          Fluttertoast.showToast(
+            msg: _localization!.trans('PIN_MISMATCH')!,
+            toastLength: Toast.LENGTH_SHORT,
+            gravity: ToastGravity.CENTER,
+            timeInSecForIosWeb: 1,
+            fontSize: 16.0,
+          );
+
+          _inputPin = '';
+        }
+      }
+    }
+
+    /// LocalAuthentication - Fingerprint
+    final LocalAuthentication _localAuthentication = LocalAuthentication();
+    var _hasFingerPrintSupport = useState<bool>(false);
+
+    Future<void> checkFingerprintSupport() async {
+      bool isBiometricSupport = false;
+      List<BiometricType> availableBiometricType = [];
+
+      try {
+        isBiometricSupport = await _localAuthentication.canCheckBiometrics;
+        if (!isBiometricSupport) return;
+      } catch (e) {
+        print(e);
+      }
+      if (!mounted()) return;
+
+      try {
+        availableBiometricType =
+            await _localAuthentication.getAvailableBiometrics();
+      } catch (e) {
+        print(e);
+      }
+      if (!mounted()) return;
+
+      if (availableBiometricType.contains(BiometricType.fingerprint)) {
+        _hasFingerPrintSupport.value = true;
+      } else {
+        _hasFingerPrintSupport.value = false;
+      }
+    }
+
+    Future<void> _authenticateMe() async {
+      // 8. this method opens a dialog for fingerprint authentication.
+      //    we do not need to create a dialog nut it pop sup from device natively.
+      bool authenticated = false;
+      try {
+        authenticated = await _localAuthentication.authenticate(
+          localizedReason:
+              _localization!.trans('FINGERPRINT_LOGIN')!, // message for dialog
+          options: AuthenticationOptions(
+            useErrorDialogs: true,
+            stickyAuth: true,
+          ),
+        );
+      } catch (e) {
+        print(e);
+      }
+      if (!mounted()) return;
+
+      if (authenticated) {
+        Navigator.pop(context, false);
+      } else {
+        return;
+      }
+    }
+
+    readLockPinFromSF() async {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+
+      if (prefs.containsKey('LOCK_PIN')) {
+        _pin = prefs.getString('LOCK_PIN');
+        print(_pin);
+      }
+    }
+
+    useEffect(() {
+      SystemChrome.setPreferredOrientations([
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ]);
+
+      checkFingerprintSupport();
+      readLockPinFromSF();
+      return () {
+        SystemChrome.setPreferredOrientations([
+          DeviceOrientation.landscapeLeft,
+          DeviceOrientation.landscapeRight,
+          DeviceOrientation.portraitDown,
+          DeviceOrientation.portraitUp,
+        ]);
+      };
+    }, []);
+
     _localization = Localization.of(context);
     _screenSize = MediaQuery.of(context).size;
+
+    void _deleteCurrentDigit() {
+      if (_fourthDigit.value != null) {
+        _fourthDigit.value = null;
+      } else if (_thirdDigit.value != null) {
+        _thirdDigit.value = null;
+      } else if (_secondDigit.value != null) {
+        _secondDigit.value = null;
+      } else if (_firstDigit.value != null) {
+        _firstDigit.value = null;
+      }
+    }
+
+    Widget _pinTextField(int? digit) {
+      return Container(
+          width: 50,
+          height: 45,
+          alignment: Alignment.center,
+          child: Text(
+            digit != null ? digit.toString() : "",
+            style: TextStyle(
+              fontSize: 30,
+              color: Theme.of(context).textTheme.displayLarge!.color,
+            ),
+          ),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: Theme.of(context).textTheme.displayLarge!.color!,
+                width: 2,
+              ),
+            ),
+          ));
+    }
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -154,10 +211,10 @@ class _LockAuthState extends State<LockAuth> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  _pinTextField(_firstDigit),
-                  _pinTextField(_secondDigit),
-                  _pinTextField(_thirdDigit),
-                  _pinTextField(_fourthDigit),
+                  _pinTextField(_firstDigit.value),
+                  _pinTextField(_secondDigit.value),
+                  _pinTextField(_thirdDigit.value),
+                  _pinTextField(_fourthDigit.value),
                 ],
               ),
             ),
@@ -167,7 +224,7 @@ class _LockAuthState extends State<LockAuth> {
                 style: TextStyle(
                     color: Theme.of(context).textTheme.displayMedium!.color),
               ),
-              onPressed: _hasFingerPrintSupport ? _authenticateMe : null,
+              onPressed: _hasFingerPrintSupport.value ? _authenticateMe : null,
               // shape: RoundedRectangleBorder(
               //   borderRadius: BorderRadius.circular(30),
               // ),
@@ -184,79 +241,5 @@ class _LockAuthState extends State<LockAuth> {
         ),
       ),
     );
-  }
-
-  void _setCurrentDigit(int i) {
-    setState(() {
-      _currentDigit = i;
-      if (_firstDigit == null) {
-        _firstDigit = _currentDigit;
-      } else if (_secondDigit == null) {
-        _secondDigit = _currentDigit;
-      } else if (_thirdDigit == null) {
-        _thirdDigit = _currentDigit;
-      } else if (_fourthDigit == null) {
-        _fourthDigit = _currentDigit;
-
-        _inputPin = _firstDigit.toString() +
-            _secondDigit.toString() +
-            _thirdDigit.toString() +
-            _fourthDigit.toString();
-
-        print('INPUT PIN is $_inputPin');
-      }
-    });
-
-    if (_inputPin.length == 4) {
-      if (_inputPin == _pin) {
-        Navigator.pop(context, false);
-      } else {
-        Fluttertoast.showToast(
-          msg: _localization!.trans('PIN_MISMATCH')!,
-          toastLength: Toast.LENGTH_SHORT,
-          gravity: ToastGravity.CENTER,
-          timeInSecForIosWeb: 1,
-          fontSize: 16.0,
-        );
-
-        _inputPin = '';
-      }
-    }
-  }
-
-  void _deleteCurrentDigit() {
-    setState(() {
-      if (_fourthDigit != null) {
-        _fourthDigit = null;
-      } else if (_thirdDigit != null) {
-        _thirdDigit = null;
-      } else if (_secondDigit != null) {
-        _secondDigit = null;
-      } else if (_firstDigit != null) {
-        _firstDigit = null;
-      }
-    });
-  }
-
-  Widget _pinTextField(int? digit) {
-    return Container(
-        width: 50,
-        height: 45,
-        alignment: Alignment.center,
-        child: Text(
-          digit != null ? digit.toString() : "",
-          style: TextStyle(
-            fontSize: 30,
-            color: Theme.of(context).textTheme.displayLarge!.color,
-          ),
-        ),
-        decoration: BoxDecoration(
-          border: Border(
-            bottom: BorderSide(
-              color: Theme.of(context).textTheme.displayLarge!.color!,
-              width: 2,
-            ),
-          ),
-        ));
   }
 }

--- a/lib/screens/lock_register.dart
+++ b/lib/screens/lock_register.dart
@@ -1,84 +1,128 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:wecount/widgets/header.dart' show renderHeaderBack;
 import 'package:wecount/widgets/pin_keyboard.dart' show PinKeyboard;
 import 'package:wecount/utils/localization.dart' show Localization;
 
-class LockRegister extends StatefulWidget {
+class LockRegister extends HookWidget {
   const LockRegister({Key? key}) : super(key: key);
 
   @override
-  _LockRegisterState createState() => _LockRegisterState();
-}
-
-class _LockRegisterState extends State<LockRegister> {
-  late Size _screenSize;
-
-  int? _currentDigit;
-
-  int? _firstDigit;
-  int? _secondDigit;
-  int? _thirdDigit;
-  int? _fourthDigit;
-
-  String? _pin = '';
-
-  readLockPinFromSF() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-
-    if (prefs.containsKey('LOCK_PIN')) {
-      _pin = prefs.getString('LOCK_PIN');
-      print(_pin);
-    }
-  }
-
-  addLockPinToSF() async {
-    if (_pin!.length != 4) {
-      return;
-    } else {
-      SharedPreferences prefs = await SharedPreferences.getInstance();
-      prefs.setString('LOCK_PIN', _pin!);
-      Navigator.of(context).pop();
-      print(_pin);
-    }
-  }
-
-  resetLockPinToSF() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    prefs.remove('LOCK_PIN');
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    resetLockPinToSF();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-    ]);
-
-    readLockPinFromSF();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-      DeviceOrientation.portraitDown,
-      DeviceOrientation.portraitUp,
-    ]);
-  }
-
-  @override
   Widget build(BuildContext context) {
+    late Size _screenSize;
+
+    var _currentDigit = useState<int?>(null);
+
+    var _firstDigit = useState<int?>(null);
+    var _secondDigit = useState<int?>(null);
+    var _thirdDigit = useState<int?>(null);
+    var _fourthDigit = useState<int?>(null);
+
+    String? _pin = '';
+
+    readLockPinFromSF() async {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+
+      if (prefs.containsKey('LOCK_PIN')) {
+        _pin = prefs.getString('LOCK_PIN');
+        print(_pin);
+      }
+    }
+
+    addLockPinToSF() async {
+      if (_pin!.length != 4) {
+        return;
+      } else {
+        SharedPreferences prefs = await SharedPreferences.getInstance();
+        prefs.setString('LOCK_PIN', _pin!);
+        Navigator.of(context).pop();
+        print(_pin);
+      }
+    }
+
+    resetLockPinToSF() async {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      prefs.remove('LOCK_PIN');
+    }
+
+    useEffect(() {
+      resetLockPinToSF();
+
+      SystemChrome.setPreferredOrientations([
+        DeviceOrientation.portraitUp,
+        DeviceOrientation.portraitDown,
+      ]);
+
+      readLockPinFromSF();
+      return () {
+        SystemChrome.setPreferredOrientations([
+          DeviceOrientation.landscapeLeft,
+          DeviceOrientation.landscapeRight,
+          DeviceOrientation.portraitDown,
+          DeviceOrientation.portraitUp,
+        ]);
+      };
+    }, []);
+
     var _localization = Localization.of(context)!;
     _screenSize = MediaQuery.of(context).size;
+
+    void _setCurrentDigit(int i) {
+      _currentDigit.value = i;
+      if (_firstDigit.value == null) {
+        _firstDigit.value = _currentDigit.value;
+      } else if (_secondDigit.value == null) {
+        _secondDigit.value = _currentDigit.value;
+      } else if (_thirdDigit.value == null) {
+        _thirdDigit.value = _currentDigit.value;
+      } else if (_fourthDigit.value == null) {
+        _fourthDigit.value = _currentDigit.value;
+
+        _pin = _firstDigit.toString() +
+            _secondDigit.toString() +
+            _thirdDigit.toString() +
+            _fourthDigit.toString();
+
+        print(_pin);
+      }
+    }
+
+    void _deleteCurrentDigit() {
+      if (_fourthDigit.value != null) {
+        _fourthDigit.value = null;
+      } else if (_thirdDigit.value != null) {
+        _thirdDigit.value = null;
+      } else if (_secondDigit.value != null) {
+        _secondDigit.value = null;
+      } else if (_firstDigit.value != null) {
+        _firstDigit.value = null;
+      }
+    }
+
+    Widget _pinTextField(int? digit) {
+      return Container(
+          width: 50,
+          height: 45,
+          alignment: Alignment.center,
+          child: Text(
+            digit != null ? digit.toString() : "",
+            style: TextStyle(
+              fontSize: 30,
+              color: Theme.of(context).textTheme.displayLarge!.color,
+            ),
+          ),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: Theme.of(context).textTheme.displayLarge!.color!,
+                width: 2,
+              ),
+            ),
+          ));
+    }
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -116,10 +160,10 @@ class _LockRegisterState extends State<LockRegister> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  _pinTextField(_firstDigit),
-                  _pinTextField(_secondDigit),
-                  _pinTextField(_thirdDigit),
-                  _pinTextField(_fourthDigit),
+                  _pinTextField(_firstDigit.value),
+                  _pinTextField(_secondDigit.value),
+                  _pinTextField(_thirdDigit.value),
+                  _pinTextField(_fourthDigit.value),
                 ],
               ),
             ),
@@ -143,63 +187,5 @@ class _LockRegisterState extends State<LockRegister> {
         ),
       ),
     );
-  }
-
-  void _setCurrentDigit(int i) {
-    setState(() {
-      _currentDigit = i;
-      if (_firstDigit == null) {
-        _firstDigit = _currentDigit;
-      } else if (_secondDigit == null) {
-        _secondDigit = _currentDigit;
-      } else if (_thirdDigit == null) {
-        _thirdDigit = _currentDigit;
-      } else if (_fourthDigit == null) {
-        _fourthDigit = _currentDigit;
-
-        _pin = _firstDigit.toString() +
-            _secondDigit.toString() +
-            _thirdDigit.toString() +
-            _fourthDigit.toString();
-
-        print(_pin);
-      }
-    });
-  }
-
-  void _deleteCurrentDigit() {
-    setState(() {
-      if (_fourthDigit != null) {
-        _fourthDigit = null;
-      } else if (_thirdDigit != null) {
-        _thirdDigit = null;
-      } else if (_secondDigit != null) {
-        _secondDigit = null;
-      } else if (_firstDigit != null) {
-        _firstDigit = null;
-      }
-    });
-  }
-
-  Widget _pinTextField(int? digit) {
-    return Container(
-        width: 50,
-        height: 45,
-        alignment: Alignment.center,
-        child: Text(
-          digit != null ? digit.toString() : "",
-          style: TextStyle(
-            fontSize: 30,
-            color: Theme.of(context).textTheme.displayLarge!.color,
-          ),
-        ),
-        decoration: BoxDecoration(
-          border: Border(
-            bottom: BorderSide(
-              color: Theme.of(context).textTheme.displayLarge!.color!,
-              width: 2,
-            ),
-          ),
-        ));
   }
 }

--- a/lib/screens/main_empty.dart
+++ b/lib/screens/main_empty.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 
@@ -7,18 +8,13 @@ import 'package:wecount/utils/localization.dart' show Localization;
 
 import '../widgets/home_header.dart' show renderHomeAppBar;
 
-class MainEmpty extends StatefulWidget {
+class MainEmpty extends HookWidget {
   const MainEmpty({
     Key? key,
     this.title = '',
   }) : super(key: key);
   final String title;
 
-  @override
-  _MainEmptyState createState() => _MainEmptyState();
-}
-
-class _MainEmptyState extends State<MainEmpty> {
   @override
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 import 'package:wecount/widgets/edit_text.dart';
@@ -16,104 +17,97 @@ class MembersArguments {
   MembersArguments({this.ledger});
 }
 
-class Members extends StatefulWidget {
+class Members extends HookWidget {
   final Ledger? ledger;
   const Members({Key? key, this.ledger}) : super(key: key);
 
   @override
-  _MembersState createState() => _MembersState();
-}
-
-class _MembersState extends State<Members> {
-  bool _isSearchMode = false;
-  List<ListItem> _filteredMembers = [];
-
-  final List<ListItem> _fakeMembers = [
-    HeadingItem(
-      numOfPeople: 4,
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Owner,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Admin,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Admin,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-    MemberItem(
-      User(
-        displayName: 'displayName',
-        email: 'email@email.com',
-        thumbURL: 'url',
-        membership: Membership.Guest,
-      ),
-    ),
-  ];
-
-  @override
-  void initState() {
-    super.initState();
-    _filteredMembers = _fakeMembers;
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _isSearchMode = useState<bool>(false);
+    var _filteredMembers = useState<List<ListItem>>([]);
+
+    final List<ListItem> _fakeMembers = [
+      HeadingItem(
+        numOfPeople: 4,
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Owner,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Admin,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Admin,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+      MemberItem(
+        User(
+          displayName: 'displayName',
+          email: 'email@email.com',
+          thumbURL: 'url',
+          membership: Membership.Guest,
+        ),
+      ),
+    ];
+
+    useEffect(() {
+      _filteredMembers.value = _fakeMembers;
+      return null;
+    }, []);
     var _localization = Localization.of(context)!;
 
     return Scaffold(
@@ -128,12 +122,10 @@ class _MembersState extends State<Members> {
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
               onPressed: () {
-                setState(() {
-                  _isSearchMode = !_isSearchMode;
-                  if (!_isSearchMode) {
-                    _filteredMembers = _fakeMembers;
-                  }
-                });
+                _isSearchMode.value = !_isSearchMode.value;
+                if (!_isSearchMode.value) {
+                  _filteredMembers.value = _fakeMembers;
+                }
               },
               child: Icon(
                 Icons.search,
@@ -145,35 +137,33 @@ class _MembersState extends State<Members> {
         ],
       ),
       body: ListView.builder(
-        itemCount: _filteredMembers.length,
+        itemCount: _filteredMembers.value.length,
         itemBuilder: (context, index) {
-          final item = _filteredMembers[index];
+          final item = _filteredMembers.value[index];
           if (item is HeadingItem) {
             return Container(
               height: 80,
               padding: EdgeInsets.symmetric(horizontal: 40),
               alignment: Alignment(-1, 0),
-              child: _isSearchMode
+              child: _isSearchMode.value
                   ? EditText(
                       key: Key('member'),
                       textInputAction: TextInputAction.next,
                       textHint: _localization.trans('SEARCH_USER_HINT'),
                       onChanged: (String str) {
-                        setState(() {
-                          _filteredMembers = _fakeMembers.where((list) {
-                            if (list is HeadingItem) {
-                              return true;
-                            } else if (list is MemberItem) {
-                              return list.user.email!
-                                      .toLowerCase()
-                                      .contains(str) ||
-                                  list.user.displayName!
-                                      .toLowerCase()
-                                      .contains(str);
-                            }
-                            return false;
-                          }).toList();
-                        });
+                        _filteredMembers.value = _fakeMembers.where((list) {
+                          if (list is HeadingItem) {
+                            return true;
+                          } else if (list is MemberItem) {
+                            return list.user.email!
+                                    .toLowerCase()
+                                    .contains(str) ||
+                                list.user.displayName!
+                                    .toLowerCase()
+                                    .contains(str);
+                          }
+                          return false;
+                        }).toList();
                       },
                     )
                   : Text(
@@ -189,9 +179,7 @@ class _MembersState extends State<Members> {
               user: item.user,
               onPressAuth: () {
                 navigation.showMembershipDialog(context, (int? val) {
-                  setState(() {
-                    item.user.changeMemberShip(val!);
-                  });
+                  item.user.changeMemberShip(val!);
                   Navigator.of(context).pop();
                 }, item.user.membership!.index);
               },

--- a/lib/screens/photo_detail.dart
+++ b/lib/screens/photo_detail.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:photo_view/photo_view.dart'
     show PhotoView, PhotoViewComputedScale;
 import 'package:flutter/material.dart';
@@ -25,7 +26,7 @@ class PhotoDetailArguments {
   });
 }
 
-class PhotoDetail extends StatefulWidget {
+class PhotoDetail extends HookWidget {
   const PhotoDetail({
     Key? key,
     this.photo,
@@ -43,11 +44,6 @@ class PhotoDetail extends StatefulWidget {
   final Function? onPressDownload;
 
   @override
-  _State createState() => _State();
-}
-
-class _State extends State<PhotoDetail> {
-  @override
   Widget build(BuildContext context) {
     var _localization = Localization.of(context)!;
     return Scaffold(
@@ -56,12 +52,12 @@ class _State extends State<PhotoDetail> {
         child: Stack(
           children: <Widget>[
             PhotoView(
-              imageProvider: widget.photoUrl != null
-                  ? NetworkImage(widget.photoUrl!)
-                  : widget.photo != null && widget.photo!.file != null
-                      ? FileImage(File(widget.photo!.file!.path))
-                      : (widget.photo != null && widget.photo!.url != null
-                              ? NetworkImage(widget.photo!.url!)
+              imageProvider: photoUrl != null
+                  ? NetworkImage(photoUrl!)
+                  : photo != null && photo!.file != null
+                      ? FileImage(File(photo!.file!.path))
+                      : (photo != null && photo!.url != null
+                              ? NetworkImage(photo!.url!)
                               : AssetImage('res/icons/icMask.png'))
                           as ImageProvider<Object>?,
               minScale: PhotoViewComputedScale.contained * 0.8,
@@ -96,19 +92,18 @@ class _State extends State<PhotoDetail> {
                 height: 56,
                 width: MediaQuery.of(context).size.width,
                 child: Row(
-                  mainAxisAlignment: widget.canShare
+                  mainAxisAlignment: canShare
                       ? MainAxisAlignment.spaceAround
                       : MainAxisAlignment.center,
                   children: <Widget>[
-                    widget.canShare
+                    canShare
                         ? Container(
                             width: 60.0,
                             height: 60.0,
                             child: RawMaterialButton(
                               padding: EdgeInsets.all(0.0),
                               shape: CircleBorder(),
-                              onPressed:
-                                  widget.onPressDownload as void Function()?,
+                              onPressed: onPressDownload as void Function()?,
                               child: Icon(
                                 Icons.file_download,
                                 color: Colors.white,
@@ -116,15 +111,14 @@ class _State extends State<PhotoDetail> {
                             ),
                           )
                         : Container(),
-                    widget.canShare
+                    canShare
                         ? Container(
                             width: 60.0,
                             height: 60.0,
                             child: RawMaterialButton(
                               padding: EdgeInsets.all(0.0),
                               shape: CircleBorder(),
-                              onPressed:
-                                  widget.onPressShare as void Function()?,
+                              onPressed: onPressShare as void Function()?,
                               child: Icon(
                                 Icons.share,
                                 color: Colors.white,
@@ -132,15 +126,14 @@ class _State extends State<PhotoDetail> {
                             ),
                           )
                         : Container(),
-                    widget.onPressDelete != null
+                    onPressDelete != null
                         ? Container(
                             width: 60.0,
                             height: 60.0,
                             child: RawMaterialButton(
                               padding: EdgeInsets.all(0.0),
                               shape: CircleBorder(),
-                              onPressed:
-                                  widget.onPressDelete as void Function()?,
+                              onPressed: onPressDelete as void Function()?,
                               child: Icon(
                                 Icons.delete,
                                 color: Colors.white,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -18,13 +18,13 @@ class ProfileMy extends HookWidget {
   @override
   Widget build(BuildContext context) {
     var _imgFile = useState<XFile?>(null);
-    var _profile = useState<User?>(null);
+    User? _profile;
 
     Future<void> _onUpdateProfile() async {
       navigation.showDialogSpinner(context);
 
       await DatabaseService().requestUpdateProfile(
-        _profile.value,
+        _profile,
         imgFile: _imgFile.value,
       );
 
@@ -59,7 +59,7 @@ class ProfileMy extends HookWidget {
           if (!snapshot.hasData) return Container();
 
           var user = snapshot.data;
-          _profile.value = User(
+          _profile = User(
             email: user.email ?? '',
             displayName: user.displayName ?? '',
             phoneNumber: user.phoneNumber ?? '',
@@ -78,9 +78,9 @@ class ProfileMy extends HookWidget {
                   children: <Widget>[
                     ProfileImageCam(
                       imgFile: _imgFile.value,
-                      imgStr: _profile.value!.thumbURL != null
-                          ? _profile.value!.thumbURL
-                          : _profile.value!.photoURL,
+                      imgStr: _profile?.thumbURL != null
+                          ? _profile!.thumbURL
+                          : _profile?.photoURL,
                       selectCamera: () async {
                         var file = await navigation.chooseImage(
                             context: context, type: 'camera');
@@ -114,7 +114,7 @@ class ProfileMy extends HookWidget {
                 controller: TextEditingController(
                   text: user.displayName,
                 ),
-                onChangeText: (String str) => _profile.value!.displayName = str,
+                onChangeText: (String str) => _profile?.displayName = str,
                 semanticLabel: _localization.trans('NICKNAME'),
                 iconData: Icons.person_outline,
                 margin: EdgeInsets.only(top: 8.0),
@@ -126,7 +126,7 @@ class ProfileMy extends HookWidget {
                 controller: TextEditingController(
                   text: user.phoneNumber,
                 ),
-                onChangeText: (String str) => _profile.value!.phoneNumber = str,
+                onChangeText: (String str) => _profile?.phoneNumber = str,
                 iconData: Icons.phone,
                 margin: EdgeInsets.only(top: 8.0),
                 hintText: _localization.trans('PHONE'),
@@ -143,7 +143,7 @@ class ProfileMy extends HookWidget {
                 controller: TextEditingController(
                   text: user.statusMsg,
                 ),
-                onChangeText: (String str) => _profile.value!.statusMsg = str,
+                onChangeText: (String str) => _profile?.statusMsg = str,
                 labelText: _localization.trans('STATUS_MESSAGE'),
                 hintText: _localization.trans('STATUS_MESSAGE_HINT'),
                 maxLines: 5,

--- a/lib/screens/profile_my.dart
+++ b/lib/screens/profile_my.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/user.dart' show User;
 import 'package:wecount/services/database.dart';
 import 'package:firebase_auth/firebase_auth.dart' as FireAuth show User;
@@ -11,31 +12,26 @@ import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
-class ProfileMy extends StatefulWidget {
+class ProfileMy extends HookWidget {
   const ProfileMy({Key? key}) : super(key: key);
 
   @override
-  _ProfileMyState createState() => _ProfileMyState();
-}
-
-class _ProfileMyState extends State<ProfileMy> {
-  XFile? _imgFile;
-  User? _profile;
-
-  Future<void> _onUpdateProfile() async {
-    navigation.showDialogSpinner(context);
-
-    await DatabaseService().requestUpdateProfile(
-      _profile,
-      imgFile: _imgFile,
-    );
-
-    Navigator.of(context).pop();
-    Navigator.of(context).pop();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _imgFile = useState<XFile?>(null);
+    var _profile = useState<User?>(null);
+
+    Future<void> _onUpdateProfile() async {
+      navigation.showDialogSpinner(context);
+
+      await DatabaseService().requestUpdateProfile(
+        _profile.value,
+        imgFile: _imgFile.value,
+      );
+
+      Navigator.of(context).pop();
+      Navigator.of(context).pop();
+    }
+
     var _localization = Localization.of(context)!;
     var _user = Provider.of<FireAuth.User>(context);
 
@@ -63,7 +59,7 @@ class _ProfileMyState extends State<ProfileMy> {
           if (!snapshot.hasData) return Container();
 
           var user = snapshot.data;
-          _profile = User(
+          _profile.value = User(
             email: user.email ?? '',
             displayName: user.displayName ?? '',
             phoneNumber: user.phoneNumber ?? '',
@@ -81,22 +77,22 @@ class _ProfileMyState extends State<ProfileMy> {
                 child: Row(
                   children: <Widget>[
                     ProfileImageCam(
-                      imgFile: _imgFile,
-                      imgStr: _profile!.thumbURL != null
-                          ? _profile!.thumbURL
-                          : _profile!.photoURL,
+                      imgFile: _imgFile.value,
+                      imgStr: _profile.value!.thumbURL != null
+                          ? _profile.value!.thumbURL
+                          : _profile.value!.photoURL,
                       selectCamera: () async {
                         var file = await navigation.chooseImage(
                             context: context, type: 'camera');
                         if (file != null) {
-                          setState(() => _imgFile = file);
+                          _imgFile.value = file;
                         }
                       },
                       selectGallery: () async {
                         var file = await navigation.chooseImage(
                             context: context, type: 'gallery');
                         if (file != null) {
-                          setState(() => _imgFile = file);
+                          _imgFile.value = file;
                         }
                       },
                     ),
@@ -118,7 +114,7 @@ class _ProfileMyState extends State<ProfileMy> {
                 controller: TextEditingController(
                   text: user.displayName,
                 ),
-                onChangeText: (String str) => _profile!.displayName = str,
+                onChangeText: (String str) => _profile.value!.displayName = str,
                 semanticLabel: _localization.trans('NICKNAME'),
                 iconData: Icons.person_outline,
                 margin: EdgeInsets.only(top: 8.0),
@@ -130,7 +126,7 @@ class _ProfileMyState extends State<ProfileMy> {
                 controller: TextEditingController(
                   text: user.phoneNumber,
                 ),
-                onChangeText: (String str) => _profile!.phoneNumber = str,
+                onChangeText: (String str) => _profile.value!.phoneNumber = str,
                 iconData: Icons.phone,
                 margin: EdgeInsets.only(top: 8.0),
                 hintText: _localization.trans('PHONE'),
@@ -147,7 +143,7 @@ class _ProfileMyState extends State<ProfileMy> {
                 controller: TextEditingController(
                   text: user.statusMsg,
                 ),
-                onChangeText: (String str) => _profile!.statusMsg = str,
+                onChangeText: (String str) => _profile.value!.statusMsg = str,
                 labelText: _localization.trans('STATUS_MESSAGE'),
                 hintText: _localization.trans('STATUS_MESSAGE_HINT'),
                 maxLines: 5,

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/user.dart';
 import 'package:wecount/screens/photo_detail.dart';
 import 'package:flutter/material.dart';
@@ -14,29 +15,24 @@ class ProfilePeerArguments {
   ProfilePeerArguments({required this.user});
 }
 
-class ProfilePeer extends StatefulWidget {
+class ProfilePeer extends HookWidget {
   final User user;
   const ProfilePeer({
     required this.user,
   });
 
   @override
-  _ProfilePeerState createState() => _ProfilePeerState();
-}
-
-class _ProfilePeerState extends State<ProfilePeer> {
-  void showImage(String photoUrl) async {
-    await navigation.navigate(
-      context,
-      AppRoute.photoDetail.path,
-      arguments: PhotoDetailArguments(
-        photoUrl: photoUrl,
-      ),
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
+    void showImage(String photoUrl) async {
+      await navigation.navigate(
+        context,
+        AppRoute.photoDetail.path,
+        arguments: PhotoDetailArguments(
+          photoUrl: photoUrl,
+        ),
+      );
+    }
+
     Localization.of(context);
 
     return Scaffold(

--- a/lib/screens/setting_currency.dart
+++ b/lib/screens/setting_currency.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/currency.dart';
 import 'package:flutter/material.dart';
 
@@ -13,7 +14,7 @@ class SettingCurrencyArguments {
   SettingCurrencyArguments({this.title = '', this.selectedCurrency});
 }
 
-class SettingCurrency extends StatefulWidget {
+class SettingCurrency extends HookWidget {
   const SettingCurrency({
     Key? key,
     this.title = '',
@@ -23,23 +24,18 @@ class SettingCurrency extends StatefulWidget {
   final String? selectedCurrency;
 
   @override
-  _SettingCurrencyState createState() => _SettingCurrencyState();
-}
-
-class _SettingCurrencyState extends State<SettingCurrency> {
-  void onSettingCurrency(Currency selectedCurrency) {
-    print('on setting currency ${selectedCurrency.toString()}');
-    Navigator.pop(context, selectedCurrency);
-  }
-
-  @override
   Widget build(BuildContext context) {
+    void onSettingCurrency(Currency selectedCurrency) {
+      print('on setting currency ${selectedCurrency.toString()}');
+      Navigator.pop(context, selectedCurrency);
+    }
+
     var _localization = Localization.of(context)!;
 
     final List<ListItem> _items = currencies
         .map((el) => TileItem(
               title: '${el.currency} | ${el.symbol}',
-              trailing: el.currency == widget.selectedCurrency
+              trailing: el.currency == selectedCurrency
                   ? Icon(Icons.check)
                   : Text(''),
               onTap: () => onSettingCurrency(Currency(

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -1,32 +1,27 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/header.dart';
 import 'package:wecount/utils/localization.dart';
 
-class SettingNotification extends StatefulWidget {
+class SettingNotification extends HookWidget {
   const SettingNotification({Key? key}) : super(key: key);
 
   @override
-  _SettingNotificationState createState() => _SettingNotificationState();
-}
-
-class _SettingNotificationState extends State<SettingNotification> {
-  bool _addLedgerSwitch = false;
-  bool _updateLedgerSwitch = false;
-
-  void _onChangeAddingLedgerSwitch(bool value) {
-    setState(() => _addLedgerSwitch = value);
-    print('value: $value');
-  }
-
-  void _onChangeUpdateLedgerSwitch(bool value) {
-    setState(() => _updateLedgerSwitch = value);
-    print('value: $value');
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _addLedgerSwitch = useState<bool>(false);
+    var _updateLedgerSwitch = useState<bool>(false);
+
+    void _onChangeAddingLedgerSwitch(bool value) {
+      _addLedgerSwitch.value = value;
+      print('value: $value');
+    }
+
+    void _onChangeUpdateLedgerSwitch(bool value) {
+      _updateLedgerSwitch.value = value;
+      print('value: $value');
+    }
+
     var _localization = Localization.of(context)!;
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -66,7 +61,7 @@ class _SettingNotificationState extends State<SettingNotification> {
                 Container(
                   padding: EdgeInsets.only(left: 40, top: 16),
                   child: Switch(
-                    value: _addLedgerSwitch,
+                    value: _addLedgerSwitch.value,
                     onChanged: _onChangeAddingLedgerSwitch,
                     activeTrackColor: Theme.of(context).primaryColor,
                     activeColor: Theme.of(context).accentColor,
@@ -93,7 +88,7 @@ class _SettingNotificationState extends State<SettingNotification> {
                 Container(
                   padding: EdgeInsets.only(left: 40, top: 16),
                   child: Switch(
-                    value: _updateLedgerSwitch,
+                    value: _updateLedgerSwitch.value,
                     onChanged: _onChangeUpdateLedgerSwitch,
                     activeTrackColor: Theme.of(context).primaryColor,
                     activeColor: Theme.of(context).accentColor,

--- a/lib/screens/setting_notification.dart
+++ b/lib/screens/setting_notification.dart
@@ -64,7 +64,7 @@ class SettingNotification extends HookWidget {
                     value: _addLedgerSwitch.value,
                     onChanged: _onChangeAddingLedgerSwitch,
                     activeTrackColor: Theme.of(context).primaryColor,
-                    activeColor: Theme.of(context).accentColor,
+                    activeColor: Theme.of(context).colorScheme.secondary,
                   ),
                 ),
               ],

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 
@@ -12,144 +13,139 @@ import 'package:wecount/utils/validator.dart' show Validator;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-class SignIn extends StatefulWidget {
+class SignIn extends HookWidget {
   const SignIn({Key? key}) : super(key: key);
 
   @override
-  _SignInState createState() => _SignInState();
-}
+  Widget build(BuildContext context) {
+    Localization? _localization;
+    var _scrollController = useScrollController();
 
-class _SignInState extends State<SignIn> {
-  Localization? _localization;
-  ScrollController _scrollController = ScrollController();
+    var _email = useState<String>("").value;
+    var _password = useState<String?>(null).value;
 
-  late String _email;
-  String? _password;
+    var _isValidEmail = useState<bool>(false).value;
+    var _isValidPassword = useState<bool>(false).value;
 
-  bool _isValidEmail = false;
-  bool _isValidPassword = false;
+    var _errorEmail = useState<String?>('').value;
+    var _errorPassword = useState<String?>('').value;
 
-  String? _errorEmail;
-  String? _errorPassword;
+    var _isSigningIn = useState<bool>(false).value;
+    var _isResendingEmail = useState<bool>(false).value;
 
-  bool _isSigningIn = false;
-  bool _isResendingEmail = false;
+    void _signIn() async {
+      if (_auth.currentUser != null) {
+        _auth.signOut();
+      }
 
-  void _signIn() async {
-    if (_auth.currentUser != null) {
-      _auth.signOut();
-    }
-
-    if (!_isValidEmail) {
-      setState(() => _errorEmail = _localization!.trans('NO_VALID_EMAIL'));
-      return;
-    }
-
-    if (!_isValidPassword) {
-      setState(() => _errorPassword = _localization!.trans('PASSWORD_HINT'));
-      return;
-    }
-
-    setState(() => _isSigningIn = true);
-
-    UserCredential auth;
-    try {
-      auth = await _auth.signInWithEmailAndPassword(
-          email: _email, password: _password!);
-
-      /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
-      if (auth.user != null && auth.user!.emailVerified) {
-        var snapshots = await _firestore
-            .collection('users')
-            .doc(auth.user!.uid)
-            .collection('ledgers')
-            .get();
-
-        var ledgers = snapshots.docs;
-
-        if (ledgers.length == 0) {
-          navigation.push(context, AppRoute.mainEmpty.path, reset: true);
-          return;
-        }
-
-        navigation.push(context, AppRoute.homeTab.path, reset: true);
+      if (!_isValidEmail) {
+        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
         return;
       }
-    } catch (err) {
-      setState(() => _isSigningIn = false);
-      switch (err) {
-        // case 'ERROR_INVALID_EMAIL':
-        //   setState(() => _errorEmail = _localization!.trans(err.currency));
-        //   break;
-        // case 'ERROR_WRONG_PASSWORD':
-        //   setState(() => _errorPassword = _localization!.trans(err.currency));
-        //   break;
-        case 'ERROR_USER_NOT_FOUND':
-        case 'ERROR_USER_DISABLED':
-        case 'ERROR_TOO_MANY_REQUESTS':
-        case 'ERROR_OPERATION_NOT_ALLOWED':
-          // General.instance.showSingleDialog(
-          //   context,
-          //   title: Text(_localization!.trans('ERROR')!),
-          //   content: Text(_localization!.trans(err.currency)!),
-          // );
-          break;
-      }
-      return;
-    }
 
-    if (auth.user != null && !auth.user!.emailVerified) {
-      navigation.showSingleDialog(
-        context,
-        title: Text(_localization!.trans('ERROR')!),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Text(_localization!.trans('EMAIL_NOT_VERIFIED')!),
-            Container(
-              margin: EdgeInsets.only(top: 32, bottom: 24),
-              child: Text(
-                _email,
-                style: TextStyle(
-                  fontSize: 24,
-                  color: Theme.of(context).secondaryHeaderColor,
+      if (!_isValidPassword) {
+        _errorPassword = _localization!.trans('PASSWORD_HINT');
+        return;
+      }
+
+      _isSigningIn = true;
+
+      UserCredential auth;
+      try {
+        auth = await _auth.signInWithEmailAndPassword(
+            email: _email, password: _password!);
+
+        /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
+        if (auth.user != null && auth.user!.emailVerified) {
+          var snapshots = await _firestore
+              .collection('users')
+              .doc(auth.user!.uid)
+              .collection('ledgers')
+              .get();
+
+          var ledgers = snapshots.docs;
+
+          if (ledgers.length == 0) {
+            navigation.push(context, AppRoute.mainEmpty.path, reset: true);
+            return;
+          }
+
+          navigation.push(context, AppRoute.homeTab.path, reset: true);
+          return;
+        }
+      } catch (err) {
+        _isSigningIn = false;
+        switch (err) {
+          // case 'ERROR_INVALID_EMAIL':
+          //   setState(() => _errorEmail = _localization!.trans(err.currency));
+          //   break;
+          // case 'ERROR_WRONG_PASSWORD':
+          //   setState(() => _errorPassword = _localization!.trans(err.currency));
+          //   break;
+          case 'ERROR_USER_NOT_FOUND':
+          case 'ERROR_USER_DISABLED':
+          case 'ERROR_TOO_MANY_REQUESTS':
+          case 'ERROR_OPERATION_NOT_ALLOWED':
+            // General.instance.showSingleDialog(
+            //   context,
+            //   title: Text(_localization!.trans('ERROR')!),
+            //   content: Text(_localization!.trans(err.currency)!),
+            // );
+            break;
+        }
+        return;
+      }
+
+      if (auth.user != null && !auth.user!.emailVerified) {
+        navigation.showSingleDialog(
+          context,
+          title: Text(_localization!.trans('ERROR')!),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(_localization!.trans('EMAIL_NOT_VERIFIED')!),
+              Container(
+                margin: EdgeInsets.only(top: 32, bottom: 24),
+                child: Text(
+                  _email,
+                  style: TextStyle(
+                    fontSize: 24,
+                    color: Theme.of(context).secondaryHeaderColor,
+                  ),
                 ),
               ),
-            ),
-            Button(
-              height: 40,
-              isLoading: _isResendingEmail,
-              onPress: () async {
-                setState(() => _isResendingEmail = true);
-                try {
-                  await auth.user!.sendEmailVerification();
-                } catch (err) {
-                  // print('unknown error occurred. ${err.message}');
-                } finally {
-                  setState(() => _isResendingEmail = false);
-                }
-              },
-              text: _localization!.trans('RESEND_EMAIL'),
-              textStyle: TextStyle(
-                color: Theme.of(context).accentColor,
-                fontSize: 16,
+              Button(
+                height: 40,
+                isLoading: _isResendingEmail,
+                onPress: () async {
+                  _isResendingEmail = true;
+                  try {
+                    await auth.user!.sendEmailVerification();
+                  } catch (err) {
+                    // print('unknown error occurred. ${err.message}');
+                  } finally {
+                    _isResendingEmail = false;
+                  }
+                },
+                text: _localization!.trans('RESEND_EMAIL'),
+                textStyle: TextStyle(
+                  color: Theme.of(context).accentColor,
+                  fontSize: 16,
+                ),
               ),
-            ),
-          ],
-        ),
-        onPress: () => _auth.signOut(),
-      );
+            ],
+          ),
+          onPress: () => _auth.signOut(),
+        );
+      }
     }
-  }
 
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
+    useEffect(() {
+      return () {
+        _scrollController.dispose();
+      };
+    }, []);
 
-  @override
-  Widget build(BuildContext context) {
     _localization = Localization.of(context);
     _scrollController = ScrollController(
       initialScrollOffset: 0.0,
@@ -177,16 +173,12 @@ class _SignInState extends State<SignIn> {
         hintStyle: TextStyle(color: Theme.of(context).hintColor),
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            this.setState(() {
-              _isValidEmail = true;
-              _errorEmail = null;
-              _email = str;
-            });
+            _isValidEmail = true;
+            _errorEmail = null;
+            _email = str;
           } else {
-            this.setState(() {
-              _isValidEmail = false;
-              _email = str;
-            });
+            _isValidEmail = false;
+            _email = str;
           }
         },
         errorText: _errorEmail,
@@ -207,16 +199,12 @@ class _SignInState extends State<SignIn> {
         hasChecked: isValidPassword,
         onChanged: (String str) {
           if (isValidPassword) {
-            this.setState(() {
-              _isValidPassword = true;
-              _errorPassword = null;
-              _password = str;
-            });
+            _isValidPassword = true;
+            _errorPassword = null;
+            _password = str;
           } else {
-            this.setState(() {
-              _isValidPassword = false;
-              _password = str;
-            });
+            _isValidPassword = false;
+            _password = str;
           }
         },
         errorText: _errorPassword,

--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -21,39 +21,39 @@ class SignIn extends HookWidget {
     Localization? _localization;
     var _scrollController = useScrollController();
 
-    var _email = useState<String>("").value;
-    var _password = useState<String?>(null).value;
+    var _email = useState<String>("");
+    var _password = useState<String?>(null);
 
-    var _isValidEmail = useState<bool>(false).value;
-    var _isValidPassword = useState<bool>(false).value;
+    var _isValidEmail = useState<bool>(false);
+    var _isValidPassword = useState<bool>(false);
 
-    var _errorEmail = useState<String?>('').value;
-    var _errorPassword = useState<String?>('').value;
+    var _errorEmail = useState<String?>('');
+    var _errorPassword = useState<String?>('');
 
-    var _isSigningIn = useState<bool>(false).value;
-    var _isResendingEmail = useState<bool>(false).value;
+    var _isSigningIn = useState<bool>(false);
+    var _isResendingEmail = useState<bool>(false);
 
     void _signIn() async {
       if (_auth.currentUser != null) {
         _auth.signOut();
       }
 
-      if (!_isValidEmail) {
-        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
+      if (!_isValidEmail.value) {
+        _errorEmail.value = _localization!.trans('NO_VALID_EMAIL');
         return;
       }
 
-      if (!_isValidPassword) {
-        _errorPassword = _localization!.trans('PASSWORD_HINT');
+      if (!_isValidPassword.value) {
+        _errorPassword.value = _localization!.trans('PASSWORD_HINT');
         return;
       }
 
-      _isSigningIn = true;
+      _isSigningIn.value = true;
 
       UserCredential auth;
       try {
         auth = await _auth.signInWithEmailAndPassword(
-            email: _email, password: _password!);
+            email: _email.value, password: _password.value!);
 
         /// Below can be removed if `StreamBuilder` in  [AuthSwitch] works correctly.
         if (auth.user != null && auth.user!.emailVerified) {
@@ -74,7 +74,7 @@ class SignIn extends HookWidget {
           return;
         }
       } catch (err) {
-        _isSigningIn = false;
+        _isSigningIn.value = false;
         switch (err) {
           // case 'ERROR_INVALID_EMAIL':
           //   setState(() => _errorEmail = _localization!.trans(err.currency));
@@ -107,7 +107,7 @@ class SignIn extends HookWidget {
               Container(
                 margin: EdgeInsets.only(top: 32, bottom: 24),
                 child: Text(
-                  _email,
+                  _email.value,
                   style: TextStyle(
                     fontSize: 24,
                     color: Theme.of(context).secondaryHeaderColor,
@@ -116,15 +116,15 @@ class SignIn extends HookWidget {
               ),
               Button(
                 height: 40,
-                isLoading: _isResendingEmail,
+                isLoading: _isResendingEmail.value,
                 onPress: () async {
-                  _isResendingEmail = true;
+                  _isResendingEmail.value = true;
                   try {
                     await auth.user!.sendEmailVerification();
                   } catch (err) {
                     // print('unknown error occurred. ${err.message}');
                   } finally {
-                    _isResendingEmail = false;
+                    _isResendingEmail.value = false;
                   }
                 },
                 text: _localization!.trans('RESEND_EMAIL'),
@@ -169,25 +169,25 @@ class SignIn extends HookWidget {
         textInputAction: TextInputAction.next,
         textLabel: _localization!.trans('EMAIL'),
         textHint: _localization!.trans('EMAIL_HINT'),
-        hasChecked: _isValidEmail,
+        hasChecked: _isValidEmail.value,
         hintStyle: TextStyle(color: Theme.of(context).hintColor),
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            _isValidEmail = true;
-            _errorEmail = null;
-            _email = str;
+            _isValidEmail.value = true;
+            _errorEmail.value = null;
+            _email.value = str;
           } else {
-            _isValidEmail = false;
-            _email = str;
+            _isValidEmail.value = false;
+            _email.value = str;
           }
         },
-        errorText: _errorEmail,
+        errorText: _errorEmail.value,
         onSubmitted: (String str) => _signIn(),
       );
     }
 
     Widget renderPasswordField() {
-      bool isValidPassword = _password != null && _password!.length > 0;
+      bool isValidPassword = _password != null && _password.value!.length > 0;
 
       return EditText(
         key: Key('password'),
@@ -199,15 +199,15 @@ class SignIn extends HookWidget {
         hasChecked: isValidPassword,
         onChanged: (String str) {
           if (isValidPassword) {
-            _isValidPassword = true;
-            _errorPassword = null;
-            _password = str;
+            _isValidPassword.value = true;
+            _errorPassword.value = null;
+            _password.value = str;
           } else {
-            _isValidPassword = false;
-            _password = str;
+            _isValidPassword.value = false;
+            _password.value = str;
           }
         },
-        errorText: _errorPassword,
+        errorText: _errorPassword.value,
         onSubmitted: (String str) => _signIn(),
       );
     }
@@ -216,7 +216,7 @@ class SignIn extends HookWidget {
       return Button(
         key: Key('sign-in-button'),
         onPress: _signIn,
-        isLoading: _isSigningIn,
+        isLoading: _isSigningIn.value,
         margin: EdgeInsets.only(top: 28.0, bottom: 8.0),
         textStyle: TextStyle(
           color: Colors.white,

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -26,17 +26,17 @@ class SignUp extends HookWidget {
     String? _displayName;
     String? _name;
 
-    var _errorEmail = useState<String?>(null).value;
-    var _errorPassword = useState<String?>(null).value;
-    var _errorPasswordConfirm = useState<String?>(null).value;
-    var _errorDisplayName = useState<String?>(null).value;
-    var _errorName = useState<String?>(null).value;
+    var _errorEmail = useState<String?>(null);
+    var _errorPassword = useState<String?>(null);
+    var _errorPasswordConfirm = useState<String?>(null);
+    var _errorDisplayName = useState<String?>(null);
+    var _errorName = useState<String?>(null);
 
-    var _isValidEmail = useState<bool>(false).value;
-    var _isValidPassword = useState<bool>(false).value;
-    var _isValidDisplayName = useState<bool>(false).value;
-    var _isValidName = useState<bool>(false).value;
-    var _isRegistering = useState<bool>(false).value;
+    var _isValidEmail = useState<bool>(false);
+    var _isValidPassword = useState<bool>(false);
+    var _isValidDisplayName = useState<bool>(false);
+    var _isValidName = useState<bool>(false);
+    var _isRegistering = useState<bool>(false);
 
     void _signUp() async {
       if (_email == null ||
@@ -47,32 +47,33 @@ class SignUp extends HookWidget {
         return;
       }
 
-      if (!_isValidEmail) {
-        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
+      if (!_isValidEmail.value) {
+        _errorEmail.value = _localization!.trans('NO_VALID_EMAIL');
         return;
       }
 
-      if (!_isValidPassword) {
-        _errorPassword = _localization!.trans('PASSWORD_HINT');
+      if (!_isValidPassword.value) {
+        _errorPassword.value = _localization!.trans('PASSWORD_HINT');
         return;
       }
 
       if (_passwordConfirm != _password) {
-        _errorPasswordConfirm = _localization!.trans('PASSWORD_CONFIRM_HINT');
+        _errorPasswordConfirm.value =
+            _localization!.trans('PASSWORD_CONFIRM_HINT');
         return;
       }
 
-      if (!_isValidDisplayName) {
-        _errorDisplayName = _localization!.trans('DISPLAY_NAME_HINT');
+      if (!_isValidDisplayName.value) {
+        _errorDisplayName.value = _localization!.trans('DISPLAY_NAME_HINT');
         return;
       }
 
-      if (!_isValidName) {
-        _errorName = _localization!.trans('NAME_HINT');
+      if (!_isValidName.value) {
+        _errorName.value = _localization!.trans('NAME_HINT');
         return;
       }
 
-      _isRegistering = true;
+      _isRegistering.value = true;
 
       try {
         final User? user = (await _auth.createUserWithEmailAndPassword(
@@ -129,7 +130,7 @@ class SignUp extends HookWidget {
           ),
         );
       } finally {
-        _isRegistering = false;
+        _isRegistering.value = false;
       }
     }
 
@@ -155,17 +156,17 @@ class SignUp extends HookWidget {
         textHint: _localization!.trans('EMAIL_HINT'),
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidEmail,
+        hasChecked: _isValidEmail.value,
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            _isValidEmail = true;
-            _errorEmail = null;
+            _isValidEmail.value = true;
+            _errorEmail.value = null;
           } else {
-            _isValidEmail = false;
+            _isValidEmail.value = false;
           }
           _email = str;
         },
-        errorText: _errorEmail,
+        errorText: _errorEmail.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -180,17 +181,17 @@ class SignUp extends HookWidget {
         isSecret: true,
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidPassword,
+        hasChecked: _isValidPassword.value,
         onChanged: (String str) {
           if (Validator.instance.validatePassword(str)) {
-            _isValidPassword = true;
-            _errorPassword = null;
+            _isValidPassword.value = true;
+            _errorPassword.value = null;
           } else {
-            _isValidPassword = false;
+            _isValidPassword.value = false;
           }
           _password = str;
         },
-        errorText: _errorPassword,
+        errorText: _errorPassword.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -211,11 +212,11 @@ class SignUp extends HookWidget {
         onChanged: (String str) {
           _passwordConfirm = str;
           if (str == _password) {
-            _errorPasswordConfirm = null;
+            _errorPasswordConfirm.value = null;
           }
           ;
         },
-        errorText: _errorPasswordConfirm,
+        errorText: _errorPasswordConfirm.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -229,17 +230,17 @@ class SignUp extends HookWidget {
         textHint: _localization!.trans('DISPLAY_NAME_HINT'),
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidDisplayName,
+        hasChecked: _isValidDisplayName.value,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            _isValidDisplayName = true;
-            _errorDisplayName = null;
+            _isValidDisplayName.value = true;
+            _errorDisplayName.value = null;
           } else {
-            _isValidDisplayName = false;
+            _isValidDisplayName.value = false;
           }
           _displayName = str;
         },
-        errorText: _errorDisplayName,
+        errorText: _errorDisplayName.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -253,17 +254,17 @@ class SignUp extends HookWidget {
         textHint: _localization!.trans('NAME_HINT'),
         textStyle: TextStyle(
             color: Theme.of(context).inputDecorationTheme.labelStyle!.color),
-        hasChecked: _isValidName,
+        hasChecked: _isValidName.value,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            _isValidName = true;
-            _errorName = null;
+            _isValidName.value = true;
+            _errorName.value = null;
           } else {
-            _isValidName = false;
+            _isValidName.value = false;
           }
           _name = str;
         },
-        errorText: _errorName,
+        errorText: _errorName.value,
         onSubmitted: (String str) => _signUp(),
       );
     }
@@ -271,7 +272,7 @@ class SignUp extends HookWidget {
     Widget renderSignUpButton() {
       return Button(
         key: Key('button-sign-up'),
-        isLoading: _isRegistering,
+        isLoading: _isRegistering.value,
         onPress: () => _signUp(),
         margin: EdgeInsets.only(top: 36.0, bottom: 48.0),
         textStyle: TextStyle(

--- a/lib/screens/sign_up.dart
+++ b/lib/screens/sign_up.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/navigation.dart';
 
 import 'package:wecount/widgets/edit_text.dart' show EditText;
@@ -12,133 +13,126 @@ import 'package:wecount/utils/asset.dart' as Asset;
 final FirebaseAuth _auth = FirebaseAuth.instance;
 final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
-class SignUp extends StatefulWidget {
+class SignUp extends HookWidget {
   const SignUp({Key? key}) : super(key: key);
 
   @override
-  _SignUpState createState() => _SignUpState();
-}
+  Widget build(BuildContext context) {
+    Localization? _localization;
 
-class _SignUpState extends State<SignUp> {
-  Localization? _localization;
+    String? _email;
+    String? _password;
+    String? _passwordConfirm;
+    String? _displayName;
+    String? _name;
 
-  String? _email;
-  String? _password;
-  String? _passwordConfirm;
-  String? _displayName;
-  String? _name;
+    var _errorEmail = useState<String?>(null).value;
+    var _errorPassword = useState<String?>(null).value;
+    var _errorPasswordConfirm = useState<String?>(null).value;
+    var _errorDisplayName = useState<String?>(null).value;
+    var _errorName = useState<String?>(null).value;
 
-  String? _errorEmail;
-  String? _errorPassword;
-  String? _errorPasswordConfirm;
-  String? _errorDisplayName;
-  String? _errorName;
+    var _isValidEmail = useState<bool>(false).value;
+    var _isValidPassword = useState<bool>(false).value;
+    var _isValidDisplayName = useState<bool>(false).value;
+    var _isValidName = useState<bool>(false).value;
+    var _isRegistering = useState<bool>(false).value;
 
-  bool _isValidEmail = false;
-  bool _isValidPassword = false;
-  bool _isValidDisplayName = false;
-  bool _isValidName = false;
-  bool _isRegistering = false;
+    void _signUp() async {
+      if (_email == null ||
+          _password == null ||
+          _passwordConfirm == null ||
+          _displayName == null ||
+          _name == null) {
+        return;
+      }
 
-  void _signUp() async {
-    if (_email == null ||
-        _password == null ||
-        _passwordConfirm == null ||
-        _displayName == null ||
-        _name == null) {
-      return;
-    }
+      if (!_isValidEmail) {
+        _errorEmail = _localization!.trans('NO_VALID_EMAIL');
+        return;
+      }
 
-    if (!_isValidEmail) {
-      setState(() => _errorEmail = _localization!.trans('NO_VALID_EMAIL'));
-      return;
-    }
+      if (!_isValidPassword) {
+        _errorPassword = _localization!.trans('PASSWORD_HINT');
+        return;
+      }
 
-    if (!_isValidPassword) {
-      setState(() => _errorPassword = _localization!.trans('PASSWORD_HINT'));
-      return;
-    }
+      if (_passwordConfirm != _password) {
+        _errorPasswordConfirm = _localization!.trans('PASSWORD_CONFIRM_HINT');
+        return;
+      }
 
-    if (_passwordConfirm != _password) {
-      setState(() => _errorPasswordConfirm =
-          _localization!.trans('PASSWORD_CONFIRM_HINT'));
-      return;
-    }
+      if (!_isValidDisplayName) {
+        _errorDisplayName = _localization!.trans('DISPLAY_NAME_HINT');
+        return;
+      }
 
-    if (!_isValidDisplayName) {
-      setState(
-          () => _errorDisplayName = _localization!.trans('DISPLAY_NAME_HINT'));
-      return;
-    }
+      if (!_isValidName) {
+        _errorName = _localization!.trans('NAME_HINT');
+        return;
+      }
 
-    if (!_isValidName) {
-      setState(() => _errorName = _localization!.trans('NAME_HINT'));
-      return;
-    }
+      _isRegistering = true;
 
-    setState(() => _isRegistering = true);
+      try {
+        final User? user = (await _auth.createUserWithEmailAndPassword(
+          email: _email!,
+          password: _password!,
+        ))
+            .user;
 
-    try {
-      final User? user = (await _auth.createUserWithEmailAndPassword(
-        email: _email!,
-        password: _password!,
-      ))
-          .user;
+        if (user != null) {
+          await user.sendEmailVerification();
+          await firestore.collection('users').doc(user.uid).set({
+            'email': _email,
+            'displayName': _displayName,
+            'name': _name,
+            'createdAt': FieldValue.serverTimestamp(),
+            'updatedAt': FieldValue.serverTimestamp(),
+            'deletedAt': null,
+          });
 
-      if (user != null) {
-        await user.sendEmailVerification();
-        await firestore.collection('users').doc(user.uid).set({
-          'email': _email,
-          'displayName': _displayName,
-          'name': _name,
-          'createdAt': FieldValue.serverTimestamp(),
-          'updatedAt': FieldValue.serverTimestamp(),
-          'deletedAt': null,
-        });
+          user.updateDisplayName(_displayName);
 
-        user.updateDisplayName(_displayName);
+          return navigation.showSingleDialog(
+            context,
+            title: Text(
+              _localization!.trans('SIGN_UP_SUCCESS_TITLE')!,
+              style: TextStyle(
+                  color: Theme.of(context).dialogTheme.titleTextStyle!.color),
+            ),
+            content: Text(
+              _localization!.trans('SIGN_UP_SUCCESS_CONTENT')!,
+              style: TextStyle(
+                  color: Theme.of(context).dialogTheme.contentTextStyle!.color),
+            ),
+            onPress: () {
+              _auth.signOut();
+              Navigator.of(context).pop();
+            },
+          );
+        }
 
-        return navigation.showSingleDialog(
+        throw Error();
+      } catch (err) {
+        navigation.showSingleDialog(
           context,
           title: Text(
-            _localization!.trans('SIGN_UP_SUCCESS_TITLE')!,
+            _localization!.trans('SIGN_UP_ERROR_TITLE')!,
             style: TextStyle(
                 color: Theme.of(context).dialogTheme.titleTextStyle!.color),
           ),
           content: Text(
-            _localization!.trans('SIGN_UP_SUCCESS_CONTENT')!,
+            _localization!.trans('SIGN_UP_ERROR_CONTENT')!,
             style: TextStyle(
                 color: Theme.of(context).dialogTheme.contentTextStyle!.color),
           ),
-          onPress: () {
-            _auth.signOut();
-            Navigator.of(context).pop();
-          },
         );
+      } finally {
+        _isRegistering = false;
       }
-
-      throw Error();
-    } catch (err) {
-      navigation.showSingleDialog(
-        context,
-        title: Text(
-          _localization!.trans('SIGN_UP_ERROR_TITLE')!,
-          style: TextStyle(
-              color: Theme.of(context).dialogTheme.titleTextStyle!.color),
-        ),
-        content: Text(
-          _localization!.trans('SIGN_UP_ERROR_CONTENT')!,
-          style: TextStyle(
-              color: Theme.of(context).dialogTheme.contentTextStyle!.color),
-        ),
-      );
-    } finally {
-      setState(() => _isRegistering = false);
     }
-  }
 
-  @override
-  Widget build(BuildContext context) {
     _localization = Localization.of(context);
 
     Widget renderSignUpText() {
@@ -164,12 +158,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidEmail,
         onChanged: (String str) {
           if (Validator.instance.validateEmail(str)) {
-            setState(() {
-              _isValidEmail = true;
-              _errorEmail = null;
-            });
+            _isValidEmail = true;
+            _errorEmail = null;
           } else {
-            setState(() => _isValidEmail = false);
+            _isValidEmail = false;
           }
           _email = str;
         },
@@ -191,12 +183,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidPassword,
         onChanged: (String str) {
           if (Validator.instance.validatePassword(str)) {
-            setState(() {
-              _isValidPassword = true;
-              _errorPassword = null;
-            });
+            _isValidPassword = true;
+            _errorPassword = null;
           } else {
-            setState(() => _isValidPassword = false);
+            _isValidPassword = false;
           }
           _password = str;
         },
@@ -218,12 +208,13 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _passwordConfirm != null &&
             _passwordConfirm != '' &&
             _passwordConfirm == _password,
-        onChanged: (String str) => setState(() {
+        onChanged: (String str) {
           _passwordConfirm = str;
           if (str == _password) {
             _errorPasswordConfirm = null;
           }
-        }),
+          ;
+        },
         errorText: _errorPasswordConfirm,
         onSubmitted: (String str) => _signUp(),
       );
@@ -241,12 +232,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidDisplayName,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            setState(() {
-              _isValidDisplayName = true;
-              _errorDisplayName = null;
-            });
+            _isValidDisplayName = true;
+            _errorDisplayName = null;
           } else {
-            setState(() => _isValidDisplayName = false);
+            _isValidDisplayName = false;
           }
           _displayName = str;
         },
@@ -267,12 +256,10 @@ class _SignUpState extends State<SignUp> {
         hasChecked: _isValidName,
         onChanged: (String str) {
           if (Validator.instance.validateNicknameOrName(str)) {
-            setState(() {
-              _isValidName = true;
-              _errorName = null;
-            });
+            _isValidName = true;
+            _errorName = null;
           } else {
-            setState(() => _isValidName = false);
+            _isValidName = false;
           }
           _name = str;
         },

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -1,59 +1,49 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:wecount/screens/tutorial.dart';
 
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/utils/routes.dart';
 
-class Splash extends StatefulWidget {
+class Splash extends HookWidget {
   const Splash({Key? key}) : super(key: key);
 
   @override
-  _SplashState createState() => _SplashState();
-}
-
-class _SplashState extends State<Splash> {
-  bool _visible = false;
-  Timer? _navigationTimer;
-  Timer? _timer;
-
-  Future<void> navigateRoute() async {
-    String initialRoute = AppRoute.tutorial.path;
-
-    _navigationTimer = Timer(Duration(milliseconds: 1500), () {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
-          overlays: SystemUiOverlay.values);
-      navigation.push(context, initialRoute, reset: true);
-    });
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    _timer = Timer(Duration(milliseconds: 1000), () {
-      setState(() {
-        this._visible = true;
-      });
-    });
-    SystemChrome.setEnabledSystemUIOverlays([]);
-    this.navigateRoute();
-  }
-
-  @override
-  void dispose() {
-    if (_timer != null) {
-      _timer!.cancel();
-    }
-    if (_navigationTimer != null) {
-      _navigationTimer!.cancel();
-    }
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    bool _visible = false;
+    Timer? _navigationTimer;
+    Timer? _timer;
+
+    Future<void> navigateRoute() async {
+      String initialRoute = AppRoute.tutorial.path;
+
+      _navigationTimer = Timer(Duration(milliseconds: 1500), () {
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+            overlays: SystemUiOverlay.values);
+        navigation.push(context, initialRoute, reset: true);
+      });
+    }
+
+    useEffect(() {
+      _timer = Timer(Duration(milliseconds: 1000), () {
+        _visible = true;
+      });
+      SystemChrome.setEnabledSystemUIOverlays([]);
+
+      navigateRoute();
+      return () {
+        if (_timer != null) {
+          _timer!.cancel();
+        }
+        if (_navigationTimer != null) {
+          _navigationTimer!.cancel();
+        }
+      };
+    }, []);
+
     return Scaffold(
       primary: true,
       body: SafeArea(

--- a/lib/screens/terms.dart
+++ b/lib/screens/terms.dart
@@ -1,13 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
-class Terms extends StatefulWidget {
+class Terms extends HookWidget {
   const Terms({Key? key}) : super(key: key);
 
-  @override
-  _TermsState createState() => _TermsState();
-}
-
-class _TermsState extends State<Terms> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -1,36 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:wecount/screens/intro.dart';
 
 import 'package:wecount/utils/localization.dart' show Localization;
 import 'package:wecount/utils/asset.dart' as Asset;
 import 'package:wecount/utils/routes.dart';
 
-class Tutorial extends StatefulWidget {
+class Tutorial extends HookWidget {
   const Tutorial({Key? key}) : super(key: key);
 
   @override
-  _TutorialState createState() => _TutorialState();
-}
-
-class _TutorialState extends State<Tutorial> {
-  final int pageCnt = 2; // 3
-  int _currentPage = 0;
-  var _pageController = PageController(
-    initialPage: 0,
-  );
-  void onNextPressed() {
-    if (_currentPage == pageCnt) {
-      Navigator.pushNamedAndRemoveUntil(
-          context, AppRoute.intro.fullPath, (_) => false);
-      return;
-    }
-    _pageController.nextPage(
-      duration: Duration(milliseconds: 300),
-      curve: Curves.easeIn,
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final int pageCnt = 2; // 3
+    var _currentPage = useState<int>(0).value;
+    var _pageController = PageController(
+      initialPage: 0,
+    );
+    void onNextPressed() {
+      if (_currentPage == pageCnt) {
+        Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
+        return;
+      }
+      _pageController.nextPage(
+        duration: Duration(milliseconds: 300),
+        curve: Curves.easeIn,
+      );
+    }
+
     var _localization = Localization.of(context)!;
 
     Widget renderPage({
@@ -152,9 +148,7 @@ class _TutorialState extends State<Tutorial> {
               Expanded(
                 child: PageView(
                   onPageChanged: (int page) {
-                    setState(() {
-                      _currentPage = page;
-                    });
+                    _currentPage = page;
                   },
                   controller: _pageController,
                   scrollDirection: Axis.horizontal,

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -17,8 +17,8 @@ class Tutorial extends HookWidget {
       initialPage: 0,
     );
     void onNextPressed() {
-      if (_currentPage == pageCnt) {
-        Navigator.pushNamedAndRemoveUntil(context, 'intro', (_) => false);
+      if (_currentPage.value == pageCnt) {
+        Navigator.pushNamedAndRemoveUntil(context, '/intro', (_) => false);
         return;
       }
       _pageController.nextPage(

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -12,7 +12,7 @@ class Tutorial extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final int pageCnt = 2; // 3
-    var _currentPage = useState<int>(0).value;
+    var _currentPage = useState<int>(0);
     var _pageController = PageController(
       initialPage: 0,
     );
@@ -148,7 +148,7 @@ class Tutorial extends HookWidget {
               Expanded(
                 child: PageView(
                   onPageChanged: (int page) {
-                    _currentPage = page;
+                    _currentPage.value = page;
                   },
                   controller: _pageController,
                   scrollDirection: Axis.horizontal,

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -173,11 +173,11 @@ class DatabaseService {
 
     await FirebaseFirestore.instance
         .collection('users')
-        .doc(_profile!.uid)
+        .doc(_profile?.uid)
         .set({
-      'displayName': _profile.displayName,
-      'phoneNumber': _profile.phoneNumber,
-      'statusMsg': _profile.statusMsg,
+      'displayName': _profile?.displayName,
+      'phoneNumber': _profile?.phoneNumber,
+      'statusMsg': _profile?.statusMsg,
     }, SetOptions(merge: true));
 
     return true;

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -115,7 +115,8 @@ final routes = {
   AppRoute.lockRegister.fullPath: (context) => const LockRegister(),
   AppRoute.lockAuth.fullPath: (context) => const LockAuth(),
   AppRoute.locationView.fullPath: (context) => const LocationView(),
-  AppRoute.ledgerEdit.fullPath: (context) => const LedgerEdit()
+  AppRoute.ledgerEdit.fullPath: (context) => const LedgerEdit(),
+  AppRoute.settingCurrency.fullPath: (context) => const SettingCurrency()
 };
 
 MaterialPageRoute onGenerateRoute(RouteSettings settings) {

--- a/lib/utils/themes.dart
+++ b/lib/utils/themes.dart
@@ -33,6 +33,11 @@ class Themes {
         bodySmall: TextStyle(color: Asset.Colors.light),
         bodyLarge: TextStyle(color: Asset.Colors.dark),
         bodyMedium: TextStyle(color: Asset.Colors.dark),
+        labelLarge: TextStyle(color: Asset.Colors.dark),
+        labelSmall: TextStyle(color: Asset.Colors.dark),
+        titleLarge: TextStyle(color: Asset.Colors.dark),
+        titleMedium: TextStyle(color: Asset.Colors.dark),
+        titleSmall: TextStyle(color: Asset.Colors.dark),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,
@@ -70,6 +75,11 @@ class Themes {
         bodySmall: TextStyle(color: Asset.Colors.dark),
         bodyLarge: TextStyle(color: Asset.Colors.light),
         bodyMedium: TextStyle(color: Asset.Colors.light),
+        labelLarge: TextStyle(color: Asset.Colors.light),
+        labelSmall: TextStyle(color: Asset.Colors.light),
+        titleLarge: TextStyle(color: Asset.Colors.light),
+        titleMedium: TextStyle(color: Asset.Colors.light),
+        titleSmall: TextStyle(color: Asset.Colors.light),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,

--- a/lib/utils/themes.dart
+++ b/lib/utils/themes.dart
@@ -31,6 +31,8 @@ class Themes {
         displayMedium: TextStyle(color: Asset.Colors.mediumGray),
         displaySmall: TextStyle(color: Asset.Colors.paleGray),
         bodySmall: TextStyle(color: Asset.Colors.light),
+        bodyLarge: TextStyle(color: Asset.Colors.dark),
+        bodyMedium: TextStyle(color: Asset.Colors.dark),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,
@@ -66,6 +68,8 @@ class Themes {
         displayMedium: TextStyle(color: Asset.Colors.paleGray),
         displaySmall: TextStyle(color: Asset.Colors.mediumGray),
         bodySmall: TextStyle(color: Asset.Colors.dark),
+        bodyLarge: TextStyle(color: Asset.Colors.light),
+        bodyMedium: TextStyle(color: Asset.Colors.light),
       ),
       colorScheme: ColorScheme.fromSwatch().copyWith(
         secondary: Asset.Colors.greenBlue,

--- a/lib/widgets/carousel.dart
+++ b/lib/widgets/carousel.dart
@@ -25,7 +25,7 @@ class Carousel extends HookWidget {
     final List<Photo> picture;
     final double? height;
     final double? viewportFraction;
-    var currentPage = useState<int?>(null).value;
+    var currentPage = useState<int?>(null);
 
     PageController? _controller;
 
@@ -114,7 +114,7 @@ class Carousel extends HookWidget {
 
     useEffect(() {
       _controller = PageController(
-        initialPage: currentPage!,
+        initialPage: currentPage.value!,
         keepPage: false,
         viewportFraction: this.viewportFraction!,
 
@@ -130,7 +130,7 @@ class Carousel extends HookWidget {
       child: PageView.builder(
         itemCount: this.picture.length,
         onPageChanged: (value) {
-          currentPage = value;
+          currentPage.value = value;
         },
         controller: _controller,
         itemBuilder: (context, index) {

--- a/lib/widgets/carousel.dart
+++ b/lib/widgets/carousel.dart
@@ -1,10 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/models/photo.dart' show Photo;
 
-class Carousel extends StatefulWidget {
+class Carousel extends HookWidget {
   final currentPage;
   final List<Photo> picture;
   final double height;
@@ -20,146 +21,122 @@ class Carousel extends StatefulWidget {
   });
 
   @override
-  _CarouselState createState() => _CarouselState(
-        picture,
-        currentPage: this.currentPage,
-        height: this.height,
-        viewportFraction: this.viewportFraction,
-      );
-}
-
-class _CarouselState extends State<Carousel> {
-  final List<Photo> picture;
-  final double? height;
-  final double? viewportFraction;
-  int? currentPage;
-
-  _CarouselState(
-    this.picture, {
-    this.currentPage,
-    this.height,
-    this.viewportFraction,
-  });
-
-  PageController? _controller;
-
-  @override
-  initState() {
-    super.initState();
-    _controller = PageController(
-      initialPage: this.currentPage!,
-      keepPage: false,
-      viewportFraction: this.viewportFraction!,
-
-      /// width percentage
-    );
-  }
-
-  @override
-  dispose() {
-    _controller!.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final List<Photo> picture;
+    final double? height;
+    final double? viewportFraction;
+    var currentPage = useState<int?>(null).value;
+
+    PageController? _controller;
+
+    builder(int index) {
+      double screenWidth = MediaQuery.of(context).size.width;
+      return AnimatedBuilder(
+        animation: _controller!,
+        builder: (context, child) {
+          double value = 1.0;
+          if (_controller!.position.haveDimensions) {
+            value = _controller!.page! - index;
+            value = (1 - (value.abs() * .5)).clamp(0.0, 1.0);
+          }
+
+          return Center(
+            child: SizedBox(
+              height: Curves.easeOut.transform(value) * this.height,
+              width: Curves.easeOut.transform(value) * screenWidth,
+              child: child,
+            ),
+          );
+        },
+        child: Container(
+          child: Stack(
+            children: <Widget>[
+              Positioned(
+                child: Container(
+                  width: double.infinity,
+                  height: this.height,
+                  child: ButtonTheme(
+                    minWidth: double.infinity,
+                    child: TextButton(
+                      onPressed: () => this.onPressed!(index),
+                      child: Row(
+                        children: <Widget>[
+                          Expanded(
+                            // child: CachedNetworkImage(
+                            //   fit: BoxFit.cover,
+                            //   placeholder: Image(
+                            //     image: Theme.Icons.icLoadingImage,
+                            //   ),
+                            //   imageUrl: imgUrls[index],
+                            // )
+                            child: Image.file(
+                              File(this.picture[index].file!.path),
+                              fit: BoxFit.cover,
+                              height: 72,
+                              width: 84,
+                            ),
+                          )
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  margin: EdgeInsets.only(bottom: 20.0),
+                  width: 72.0,
+                  height: 24.0,
+                  decoration: BoxDecoration(
+                    color: Color.fromRGBO(0, 0, 0, 0.3),
+                    borderRadius: BorderRadius.circular(14.0),
+                  ),
+                  child: Center(
+                    child: Text(
+                      '${index + 1} / ${this.picture.length}',
+                      style: TextStyle(
+                        color: const Color(0xffffffff),
+                        fontWeight: FontWeight.w100,
+                        fontFamily: "AppleSDGothicNeo",
+                        fontStyle: FontStyle.normal,
+                        fontSize: 14.0,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    useEffect(() {
+      _controller = PageController(
+        initialPage: currentPage!,
+        keepPage: false,
+        viewportFraction: this.viewportFraction!,
+
+        /// width percentage
+      );
+      return () {
+        _controller!.dispose();
+      };
+    }, []);
+
     return Container(
       height: this.height,
       child: PageView.builder(
-        itemCount: picture.length,
+        itemCount: this.picture.length,
         onPageChanged: (value) {
-          setState(() {
-            this.currentPage = value;
-          });
+          currentPage = value;
         },
         controller: _controller,
         itemBuilder: (context, index) {
           return builder(index);
         },
         pageSnapping: true,
-      ),
-    );
-  }
-
-  builder(int index) {
-    double screenWidth = MediaQuery.of(context).size.width;
-    return AnimatedBuilder(
-      animation: _controller!,
-      builder: (context, child) {
-        double value = 1.0;
-        if (_controller!.position.haveDimensions) {
-          value = _controller!.page! - index;
-          value = (1 - (value.abs() * .5)).clamp(0.0, 1.0);
-        }
-
-        return Center(
-          child: SizedBox(
-            height: Curves.easeOut.transform(value) * widget.height,
-            width: Curves.easeOut.transform(value) * screenWidth,
-            child: child,
-          ),
-        );
-      },
-      child: Container(
-        child: Stack(
-          children: <Widget>[
-            Positioned(
-              child: Container(
-                width: double.infinity,
-                height: widget.height,
-                child: ButtonTheme(
-                  minWidth: double.infinity,
-                  child: TextButton(
-                    onPressed: () => widget.onPressed!(index),
-                    child: Row(
-                      children: <Widget>[
-                        Expanded(
-                          // child: CachedNetworkImage(
-                          //   fit: BoxFit.cover,
-                          //   placeholder: Image(
-                          //     image: Theme.Icons.icLoadingImage,
-                          //   ),
-                          //   imageUrl: imgUrls[index],
-                          // )
-                          child: Image.file(
-                            File(widget.picture[index].file!.path),
-                            fit: BoxFit.cover,
-                            height: 72,
-                            width: 84,
-                          ),
-                        )
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Container(
-                margin: EdgeInsets.only(bottom: 20.0),
-                width: 72.0,
-                height: 24.0,
-                decoration: BoxDecoration(
-                  color: Color.fromRGBO(0, 0, 0, 0.3),
-                  borderRadius: BorderRadius.circular(14.0),
-                ),
-                child: Center(
-                  child: Text(
-                    '${index + 1} / ${picture.length}',
-                    style: TextStyle(
-                      color: const Color(0xffffffff),
-                      fontWeight: FontWeight.w100,
-                      fontFamily: "AppleSDGothicNeo",
-                      fontStyle: FontStyle.normal,
-                      fontSize: 14.0,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/widgets/category_item.dart
+++ b/lib/widgets/category_item.dart
@@ -1,8 +1,9 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/category.dart';
 import 'package:flutter/material.dart';
 
-class CategoryItem extends StatefulWidget {
+class CategoryItem extends HookWidget {
   CategoryItem({
     this.key,
     required this.category,
@@ -15,24 +16,16 @@ class CategoryItem extends StatefulWidget {
   final Function? onSelectPressed;
 
   @override
-  _CategoryItemState createState() => _CategoryItemState(category);
-}
-
-class _CategoryItemState extends State<CategoryItem> {
-  _CategoryItemState(this.category);
-  Category category;
-
-  @override
   Widget build(BuildContext context) {
+    var category = useState<Category>(this.category).value;
+
     return Container(
       margin: EdgeInsets.only(top: 10, bottom: 10, left: 8),
       child: InkWell(
         onTap: () {
-          widget.onSelectPressed!();
+          onSelectPressed!();
         },
-        onLongPress: () => setState(() {
-          category.showDelete = !category.showDelete;
-        }),
+        onLongPress: () => category.showDelete = !category.showDelete,
         child: Stack(
           children: <Widget>[
             Column(
@@ -64,7 +57,7 @@ class _CategoryItemState extends State<CategoryItem> {
                   ? Container(
                       padding: EdgeInsets.all(2),
                       child: InkWell(
-                        onTap: widget.onDeletePressed as void Function()?,
+                        onTap: onDeletePressed as void Function()?,
                         child: ClipOval(
                           child: Container(
                             width: 24,

--- a/lib/widgets/category_item.dart
+++ b/lib/widgets/category_item.dart
@@ -17,7 +17,7 @@ class CategoryItem extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    var category = useState<Category>(this.category).value;
+    var category = useState<Category>(this.category);
 
     return Container(
       margin: EdgeInsets.only(top: 10, bottom: 10, left: 8),
@@ -25,13 +25,14 @@ class CategoryItem extends HookWidget {
         onTap: () {
           onSelectPressed!();
         },
-        onLongPress: () => category.showDelete = !category.showDelete,
+        onLongPress: () =>
+            category.value.showDelete = !category.value.showDelete,
         child: Stack(
           children: <Widget>[
             Column(
               children: <Widget>[
                 Image(
-                  image: category.getIconImage()!,
+                  image: category.value.getIconImage()!,
                   width: 72,
                   height: 72,
                 ),
@@ -39,7 +40,7 @@ class CategoryItem extends HookWidget {
                   margin: EdgeInsets.only(top: 8),
                   width: 80,
                   child: AutoSizeText(
-                    category.label ?? '',
+                    category.value.label ?? '',
                     style: TextStyle(
                       fontSize: 16,
                       color: Theme.of(context).textTheme.displayLarge!.color,
@@ -53,7 +54,7 @@ class CategoryItem extends HookWidget {
             Positioned(
               right: 0,
               top: 0,
-              child: category.showDelete
+              child: category.value.showDelete
                   ? Container(
                       padding: EdgeInsets.all(2),
                       child: InkWell(

--- a/lib/widgets/category_list.dart
+++ b/lib/widgets/category_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/category.dart';
 import 'package:wecount/utils/navigation.dart';
 import 'package:wecount/widgets/category_item.dart';
@@ -6,22 +7,16 @@ import 'package:wecount/utils/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 
-class CategoryList extends StatefulWidget {
+class CategoryList extends HookWidget {
   CategoryList({
     required this.categories,
   });
   final List<Category> categories;
 
   @override
-  _CategoryListState createState() => _CategoryListState(categories);
-}
-
-class _CategoryListState extends State<CategoryList> {
-  List<Category> categories;
-  _CategoryListState(this.categories);
-
-  @override
   Widget build(BuildContext context) {
+    var categories = useState<List<Category>>(this.categories).value;
+
     var _localization = Localization.of(context);
     return SafeArea(
       child: SingleChildScrollView(
@@ -50,9 +45,7 @@ class _CategoryListState extends State<CategoryList> {
                       fontSize: 16.0,
                     );
                   } finally {
-                    this.setState(() {
-                      categories.remove(category);
-                    });
+                    categories.remove(category);
                     Fluttertoast.showToast(
                       msg: _localization.trans('CATEGORY_DELETED')!,
                       toastLength: Toast.LENGTH_SHORT,

--- a/lib/widgets/category_list.dart
+++ b/lib/widgets/category_list.dart
@@ -15,13 +15,13 @@ class CategoryList extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    var categories = useState<List<Category>>(this.categories).value;
+    var categories = useState<List<Category>>(this.categories);
 
     var _localization = Localization.of(context);
     return SafeArea(
       child: SingleChildScrollView(
         child: Wrap(
-          children: categories.map((Category category) {
+          children: categories.value.map((Category category) {
             return CategoryItem(
               key: Key(category.id.toString()),
               category: category,
@@ -45,7 +45,7 @@ class CategoryList extends HookWidget {
                       fontSize: 16.0,
                     );
                   } finally {
-                    categories.remove(category);
+                    categories.value.remove(category);
                     Fluttertoast.showToast(
                       msg: _localization.trans('CATEGORY_DELETED')!,
                       toastLength: Toast.LENGTH_SHORT,

--- a/lib/widgets/edit_text_box.dart
+++ b/lib/widgets/edit_text_box.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/utils/asset.dart' as Asset;
 
-class EditTextBox extends StatefulWidget {
+class EditTextBox extends HookWidget {
   const EditTextBox({
     this.key,
     this.enabled = true,
@@ -54,57 +55,52 @@ class EditTextBox extends StatefulWidget {
   final BorderStyle borderStyle;
 
   @override
-  _EditTextBoxState createState() => _EditTextBoxState();
-}
-
-class _EditTextBoxState extends State<EditTextBox> {
-  FocusNode _focus = FocusNode();
-
-  @override
   Widget build(BuildContext context) {
+    FocusNode _focus = FocusNode();
+
     return Stack(
       alignment: Alignment.center,
       children: <Widget>[
-        widget.iconData != null
+        iconData != null
             ? Positioned(
                 left: 12,
                 bottom: 0,
-                top: widget.margin.top,
+                top: margin.top,
                 child: Container(
                   child: Icon(
-                    widget.iconData,
-                    color: widget.enabledColor,
-                    semanticLabel: widget.semanticLabel,
-                    size: widget.iconSize,
+                    iconData,
+                    color: enabledColor,
+                    semanticLabel: semanticLabel,
+                    size: iconSize,
                   ),
                 ),
               )
             : Container(),
         Container(
           child: TextField(
-            enabled: widget.enabled,
-            controller: widget.controller,
-            style: widget.textStyle ??
+            enabled: enabled,
+            controller: controller,
+            style: textStyle ??
                 TextStyle(
                     color: Theme.of(context).textTheme.displayLarge!.color),
-            cursorColor: widget.focusedColor,
-            onChanged: widget.onChangeText as void Function(String)?,
-            maxLength: widget.maxLength,
+            cursorColor: focusedColor,
+            onChanged: onChangeText as void Function(String)?,
+            maxLength: maxLength,
             focusNode: _focus,
-            maxLines: widget.maxLines,
+            maxLines: maxLines,
             decoration: InputDecoration(
               alignLabelWithHint: true,
-              labelText: widget.labelText,
-              labelStyle: widget.labelStyle,
-              focusColor: widget.focusedColor,
-              hintText: widget.hintText,
-              hintStyle: widget.hintStyle ??
+              labelText: labelText,
+              labelStyle: labelStyle,
+              focusColor: focusedColor,
+              hintText: hintText,
+              hintStyle: hintStyle ??
                   TextStyle(
                       color: Theme.of(context).textTheme.displaySmall!.color),
-              errorText: widget.errorText,
-              errorStyle: widget.errorStyle,
+              errorText: errorText,
+              errorStyle: errorStyle,
               contentPadding: EdgeInsets.only(
-                left: widget.iconData != null ? 48 : 16,
+                left: iconData != null ? 48 : 16,
                 top: 22,
                 bottom: 22,
                 right: 16,
@@ -112,47 +108,47 @@ class _EditTextBoxState extends State<EditTextBox> {
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.focusedColor!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: focusedColor!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.enabledColor!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: enabledColor!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               disabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.disabledColor,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: disabledColor,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               errorBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.errorStyle.color!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: errorStyle.color!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
               focusedErrorBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
-                  color: widget.errorStyle.color!,
-                  width: widget.borderWidth,
-                  style: widget.borderStyle,
+                  color: errorStyle.color!,
+                  width: borderWidth,
+                  style: borderStyle,
                 ),
               ),
             ),
             autocorrect: false,
           ),
-          margin: widget.margin,
+          margin: margin,
         ),
       ],
     );

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:wecount/models/ledger_item.dart';
 import 'package:flutter/material.dart';
 
@@ -82,7 +83,7 @@ Future<PhotoOption?> _asyncPhotoSelect(BuildContext context) async {
       });
 }
 
-class Gallery extends StatefulWidget {
+class Gallery extends HookWidget {
   Gallery({
     this.margin,
     this.showAll = false,
@@ -96,26 +97,19 @@ class Gallery extends StatefulWidget {
   final LedgerItem ledgerItem;
 
   @override
-  _GalleryState createState() => _GalleryState();
-}
-
-class _GalleryState extends State<Gallery> {
-  late List<Photo> _pictures;
-
-  @override
-  void initState() {
-    _pictures = widget.pictures;
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    var _pictures = useState<List<Photo>>([]).value;
+
+    useEffect(() {
+      _pictures = pictures;
+    }, []);
+
     var _localization = Localization.of(context)!;
 
     void onPressShowAll() {}
 
     return Container(
-      margin: widget.margin,
+      margin: margin,
       child: Column(
         children: <Widget>[
           Row(
@@ -143,7 +137,7 @@ class _GalleryState extends State<Gallery> {
                   ],
                 ),
               ),
-              widget.showAll
+              showAll
                   ? TextButton(
                       onPressed: onPressShowAll,
                       child: Text(
@@ -187,10 +181,8 @@ class _GalleryState extends State<Gallery> {
 
                         if (imgFile != null) {
                           Photo photo = Photo(file: imgFile);
-                          setState(() {
-                            _pictures.add(photo);
-                          });
-                          widget.ledgerItem.picture = _pictures;
+                          _pictures.add(photo);
+                          ledgerItem.picture = _pictures;
                         }
                       },
                       child: Container(
@@ -242,7 +234,7 @@ class _GalleryState extends State<Gallery> {
                                         (Photo compare) =>
                                             compare.file == photo.file);
                                     _pictures.removeAt(index);
-                                    widget.ledgerItem.picture = _pictures;
+                                    ledgerItem.picture = _pictures;
                                     Navigator.of(context).pop();
                                   },
                                 ),

--- a/lib/widgets/gallery.dart
+++ b/lib/widgets/gallery.dart
@@ -98,10 +98,10 @@ class Gallery extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    var _pictures = useState<List<Photo>>([]).value;
+    var _pictures = useState<List<Photo>>([]);
 
     useEffect(() {
-      _pictures = pictures;
+      _pictures.value = pictures;
     }, []);
 
     var _localization = Localization.of(context)!;
@@ -157,7 +157,7 @@ class Gallery extends HookWidget {
             width: double.infinity,
             margin: EdgeInsets.only(bottom: 32),
             child: Wrap(
-              children: _pictures.map((Photo photo) {
+              children: _pictures.value.map((Photo photo) {
                 if (photo.isAddBtn == true) {
                   return Container(
                     padding: EdgeInsets.only(right: 4, bottom: 6),
@@ -181,8 +181,8 @@ class Gallery extends HookWidget {
 
                         if (imgFile != null) {
                           Photo photo = Photo(file: imgFile);
-                          _pictures.add(photo);
-                          ledgerItem.picture = _pictures;
+                          _pictures.value.add(photo);
+                          ledgerItem.picture = _pictures.value;
                         }
                       },
                       child: Container(
@@ -230,11 +230,11 @@ class Gallery extends HookWidget {
                                 arguments: PhotoDetailArguments(
                                   photo: photo,
                                   onPressDelete: () {
-                                    int index = _pictures.indexWhere(
+                                    int index = _pictures.value.indexWhere(
                                         (Photo compare) =>
                                             compare.file == photo.file);
-                                    _pictures.removeAt(index);
-                                    ledgerItem.picture = _pictures;
+                                    _pictures.value.removeAt(index);
+                                    ledgerItem.picture = _pictures.value;
                                     Navigator.of(context).pop();
                                   },
                                 ),

--- a/lib/widgets/home_header_search.dart
+++ b/lib/widgets/home_header_search.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'package:wecount/widgets/edit_text_search.dart' show EditTextSearch;
 import 'package:wecount/utils/localization.dart' show Localization;
 
-class HomeHeaderSearch extends StatefulWidget {
+class HomeHeaderSearch extends HookWidget {
   HomeHeaderSearch(
       {Key? key,
       this.margin,
@@ -25,24 +26,17 @@ class HomeHeaderSearch extends StatefulWidget {
   final Function onPressDelete;
 
   @override
-  _HomeHeaderSearchState createState() => _HomeHeaderSearchState();
-}
-
-class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
-  var searchText = "";
-
-  @override
   Widget build(BuildContext context) {
+    var searchText = useState<String>("");
+
     var localization = Localization.of(context)!;
     var textInput = EditTextSearch(
-      controller: widget.textEditingController,
+      controller: textEditingController,
       textInputAction: TextInputAction.search,
       onChanged: (text) {
-        setState(() {
-          searchText = text;
-        });
+        searchText.value = text;
       },
-      onSubmit: widget.onSubmit,
+      onSubmit: onSubmit,
       background: Colors.transparent,
       txtHint: localization.trans('PLZ_SEARCH'),
       underline: false,
@@ -79,13 +73,11 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
         left: 32.0,
         top: 12.0,
       ),
-      searchText != ""
+      searchText.value != ""
           ? Positioned(
               child: Container(
                 child: RawMaterialButton(
-                  onPressed: () {
-                    widget.onPressDelete();
-                  },
+                  onPressed: () => onPressDelete(),
                   shape: CircleBorder(),
                   child: Icon(Icons.close, color: Colors.white),
                   padding: EdgeInsets.all(0.0),
@@ -100,9 +92,7 @@ class _HomeHeaderSearchState extends State<HomeHeaderSearch> {
                 child: RawMaterialButton(
                   padding: EdgeInsets.all(0.0),
                   shape: CircleBorder(),
-                  onPressed: () {
-                    widget.onPressAdd();
-                  },
+                  onPressed: () => onPressAdd(),
                   child: Icon(
                     Icons.add,
                     color: Colors.white,

--- a/lib/widgets/setting_list_item.dart
+++ b/lib/widgets/setting_list_item.dart
@@ -92,7 +92,10 @@ class SettingTileItem extends StatelessWidget {
       onTap: item.onTap as void Function()?,
       child: ListTile(
         leading: item.leading,
-        title: Text(item.title!),
+        title: Text(
+          item.title!,
+          style: TextStyle(color: Colors.black),
+        ),
         trailing: item.trailing,
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_native_image: ^0.0.6+1
   logger: ^1.1.0
   flutter_spinkit: ^5.1.0
+  flutter_hooks: ^0.18.5+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Change all `StatefulWidget` to `hookWidget` using [flutter_hooks][fluuterHookLink] package.
`flutter_hooks` make your code concise and intuitive like Example.

The class containing the variable disappears, and the variable is put in [useState][useStateLink].
Use [useEffect][useEffectLink] instead of super.initState() to handle sideEffect.

## Example

### StatefulWidget
```dart
class MyHomePage extends StatefulWidget {
  @override
  _MyHomePageState createState() => new _MyHomePageState();
}
class _MyHomePageState extends State<MyHomePage> {
  final store = MyStore();
  
  _MyHomePageState();

  @override
  Widget build(BuildContext context) {
    return Container();
  }
}
```

### HookWidget
```dart
class MyHomePage extends HookWidget {
  @override
  Widget build(BuildContext context) {
    final store = useMemoized(() => MyStore());
    return Container();
  }
}
```


[fluuterHookLink]:https://pub.dev/packages/flutter_hooks
[useStateLink]:https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useState.html
[useEffectLink]:https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/useEffect.html